### PR TITLE
Add a pass to "zonk"

### DIFF
--- a/bust/CMakeLists.txt
+++ b/bust/CMakeLists.txt
@@ -71,7 +71,8 @@ add_executable(bust-test
   test/src/type_unifier_test.cpp
   test/src/evaluator_test.cpp
   test/src/codegen_test.cpp
-  test/src/validate_main_test.cpp)
+  test/src/validate_main_test.cpp
+  test/src/zonker_test.cpp)
 
 target_compile_options(bust-test PRIVATE ${PROJECT_WARNINGS})
 
@@ -115,5 +116,6 @@ add_test(NAME bust.type_checker COMMAND bust-test -ts=bust.type_checker)
 add_test(NAME bust.type_unifier COMMAND bust-test -ts=bust.type_unifier)
 add_test(NAME bust.evaluator COMMAND bust-test -ts=bust.evaluator)
 add_test(NAME bust.codegen COMMAND bust-test -ts=bust.codegen)
+add_test(NAME bust.zonker COMMAND bust-test -ts=bust.zonker)
 
 #*****************************************************************************

--- a/bust/CMakeLists.txt
+++ b/bust/CMakeLists.txt
@@ -44,6 +44,9 @@ add_library(bust-lib STATIC
   src/type_checker.cpp
   src/validate_main.cpp
   src/zonker.cpp
+  zonk/expression_zonker.cpp
+  zonk/let_binding_zonker.cpp
+  zonk/statement_zonker.cpp
   zonk/top_item_zonker.cpp)
 
 set_target_properties(bust-lib PROPERTIES OUTPUT_NAME bust)

--- a/bust/CMakeLists.txt
+++ b/bust/CMakeLists.txt
@@ -42,7 +42,9 @@ add_library(bust-lib STATIC
   codegen/statement_generator.cpp
   codegen/top_item_generator.cpp
   src/type_checker.cpp
-  src/validate_main.cpp)
+  src/validate_main.cpp
+  src/zonker.cpp
+  zonk/top_item_zonker.cpp)
 
 set_target_properties(bust-lib PROPERTIES OUTPUT_NAME bust)
 

--- a/bust/hir/nodes.hpp
+++ b/bust/hir/nodes.hpp
@@ -11,6 +11,7 @@
 #include "ast/nodes.hpp"
 #include "hir/type_registry.hpp"
 #include <hir/types.hpp>
+#include <hir/unifier_state.hpp>
 #include <nodes.hpp>
 #include <operators.hpp>
 #include <optional>
@@ -130,6 +131,7 @@ struct FunctionDef : public core::HasLocation {
 struct Program : public core::HasLocation {
   TypeRegistry m_type_registry{};
   std::vector<TopItem> m_top_items{};
+  std::optional<UnifierState> m_unifier_state{};
 };
 
 //****************************************************************************

--- a/bust/hir/type_registry.hpp
+++ b/bust/hir/type_registry.hpp
@@ -39,7 +39,14 @@ struct TypeRegistry {
     return next_type_id;
   }
 
-  const TypeKind &get(TypeId id) const { return m_types[id.m_id]; }
+  const TypeKind &get(TypeId id) const {
+    if (id.m_id >= m_types.size()) {
+      throw core::InternalCompilerError(
+          "TypeRegistry::get() out of bounds: id " + std::to_string(id.m_id) +
+          ", size " + std::to_string(m_types.size()));
+    }
+    return m_types[id.m_id];
+  }
 
   std::string to_string(const TypeKind &);
   std::string to_string(TypeId);

--- a/bust/hir/type_unifier.hpp
+++ b/bust/hir/type_unifier.hpp
@@ -10,6 +10,7 @@
 
 #include "hir/type_registry.hpp"
 #include <hir/types.hpp>
+#include <hir/unifier_state.hpp>
 #include <hir/union_find.hpp>
 #include <ranges>
 #include <stdexcept>
@@ -295,6 +296,11 @@ struct TypeUnifier {
 
     // Not a concrete type yet
     return m_type_registry.intern(TypeVariable{root});
+  }
+
+  UnifierState extract_state() {
+    return {std::move(m_union_find), std::move(m_resolved_type_id),
+            std::move(m_resolved_type_class)};
   }
 
   TypeRegistry &m_type_registry;

--- a/bust/hir/unifier_state.hpp
+++ b/bust/hir/unifier_state.hpp
@@ -1,0 +1,30 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Moveable state extracted from TypeUnifier, stored in
+//*            hir::Program so downstream passes (zonking) can resolve
+//*            type variables without needing the full unifier.
+//*
+//*
+//****************************************************************************
+#pragma once
+//****************************************************************************
+
+#include <hir/types.hpp>
+#include <hir/union_find.hpp>
+#include <types.hpp>
+#include <unordered_map>
+
+//****************************************************************************
+namespace bust::hir {
+//****************************************************************************
+
+struct UnifierState {
+  UnionFind m_union_find{};
+  std::unordered_map<size_t, TypeId> m_resolved_type_id{};
+  std::unordered_map<size_t, PrimitiveTypeClass> m_resolved_type_class{};
+};
+
+//****************************************************************************
+} // namespace bust::hir
+//****************************************************************************

--- a/bust/inc/zonker.hpp
+++ b/bust/inc/zonker.hpp
@@ -1,0 +1,27 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Zonking pass — resolves all type variables in the HIR
+//*            to their concrete types after type checking.
+//*
+//*
+//****************************************************************************
+#pragma once
+//****************************************************************************
+
+#include <hir/nodes.hpp>
+
+//****************************************************************************
+namespace bust {
+//****************************************************************************
+
+/// Zonking pass. Consumes the unifier state attached to the program and
+/// deep-resolves every TypeId, guaranteeing no TypeVariables remain in
+/// the output.
+struct Zonker {
+  hir::Program operator()(hir::Program program);
+};
+
+//****************************************************************************
+} // namespace bust
+//****************************************************************************

--- a/bust/src/bust.cpp
+++ b/bust/src/bust.cpp
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <utility>
 #include <validate_main.hpp>
+#include <zonker.hpp>
 
 #include <lexer.hpp>
 
@@ -43,7 +44,8 @@ void Bust::run() {
     std::cout << "=== AST ===\n" << ast::Dumper::dump(program) << "\n";
   }
 
-  auto typed = run_pipeline(std::move(program), ValidateMain{}, TypeChecker{});
+  auto typed =
+      run_pipeline(std::move(program), ValidateMain{}, TypeChecker{}, Zonker{});
 
   if (m_options.dump_hir) {
     std::cout << "=== HIR ===\n" << hir::Dumper::dump(typed) << "\n";

--- a/bust/src/type_checker.cpp
+++ b/bust/src/type_checker.cpp
@@ -44,8 +44,10 @@ hir::Program TypeChecker::operator()(const ast::Program &program) {
     typed_items.push_back(std::visit(hir::TopItemChecker{context}, top_item));
   }
 
-  return {
-      {program.m_location}, std::move(type_registry), std::move(typed_items)};
+  return {{program.m_location},
+          std::move(type_registry),
+          std::move(typed_items),
+          context.m_type_unifier.extract_state()};
 }
 
 //****************************************************************************

--- a/bust/src/zonker.cpp
+++ b/bust/src/zonker.cpp
@@ -23,14 +23,14 @@ hir::Program Zonker::operator()(hir::Program program) {
         "zonker invoked on program without unifier state");
   }
 
-  auto &unifier_state = program.m_unifier_state.value();
+  auto ctx =
+      zonk::Context{program.m_type_registry, program.m_unifier_state.value()};
 
   std::vector<hir::TopItem> zonked_items;
   zonked_items.reserve(program.m_top_items.size());
   for (auto &top_item : program.m_top_items) {
     zonked_items.push_back(
-        std::visit(zonk::TopItemZonker{program.m_type_registry, unifier_state},
-                   std::move(top_item)));
+        std::visit(zonk::TopItemZonker{ctx}, std::move(top_item)));
   }
 
   return {{program.m_location},

--- a/bust/src/zonker.cpp
+++ b/bust/src/zonker.cpp
@@ -23,8 +23,10 @@ hir::Program Zonker::operator()(hir::Program program) {
         "zonker invoked on program without unifier state");
   }
 
-  auto ctx =
-      zonk::Context{program.m_type_registry, program.m_unifier_state.value()};
+  auto ctx = zonk::Context{
+      program.m_type_registry,
+      zonk::TypeResolver{program.m_type_registry,
+                         std::move(program.m_unifier_state.value())}};
 
   std::vector<hir::TopItem> zonked_items;
   zonked_items.reserve(program.m_top_items.size());

--- a/bust/src/zonker.cpp
+++ b/bust/src/zonker.cpp
@@ -1,0 +1,44 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Implementation of the Zonker pipeline pass.
+//*
+//*
+//****************************************************************************
+
+#include <exceptions.hpp>
+#include <hir/nodes.hpp>
+#include <variant>
+#include <vector>
+#include <zonk/top_item_zonker.hpp>
+#include <zonker.hpp>
+
+//****************************************************************************
+namespace bust {
+//****************************************************************************
+
+hir::Program Zonker::operator()(hir::Program program) {
+  if (!program.m_unifier_state.has_value()) {
+    throw core::InternalCompilerError(
+        "zonker invoked on program without unifier state");
+  }
+
+  auto &unifier_state = program.m_unifier_state.value();
+
+  std::vector<hir::TopItem> zonked_items;
+  zonked_items.reserve(program.m_top_items.size());
+  for (auto &top_item : program.m_top_items) {
+    zonked_items.push_back(
+        std::visit(zonk::TopItemZonker{program.m_type_registry, unifier_state},
+                   std::move(top_item)));
+  }
+
+  return {{program.m_location},
+          std::move(program.m_type_registry),
+          std::move(zonked_items),
+          {}};
+}
+
+//****************************************************************************
+} // namespace bust
+//****************************************************************************

--- a/bust/src/zonker.cpp
+++ b/bust/src/zonker.cpp
@@ -36,7 +36,7 @@ hir::Program Zonker::operator()(hir::Program program) {
   }
 
   return {{program.m_location},
-          std::move(program.m_type_registry),
+          std::move(ctx.m_new_type_registry),
           std::move(zonked_items),
           {}};
 }

--- a/bust/test/src/zonker_test.cpp
+++ b/bust/test/src/zonker_test.cpp
@@ -1,0 +1,123 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Unit tests for bust::Zonker
+//*
+//*
+//*  See Also: https://github.com/doctest/doctest
+//*            for more on the 'DocTest' project.
+//*
+//*
+//****************************************************************************
+
+#include <hir/nodes.hpp>
+#include <hir/types.hpp>
+#include <lexer.hpp>
+#include <parser.hpp>
+#include <type_checker.hpp>
+#include <variant>
+#include <zonker.hpp>
+
+#include <doctest/doctest.h>
+#include <sstream>
+
+//****************************************************************************
+namespace bust {
+//****************************************************************************
+TEST_SUITE("bust.zonker") {
+
+  // --- Helpers -------------------------------------------------------------
+
+  static hir::Program zonk_string(const std::string &source) {
+    std::istringstream input(source);
+    auto lexer = make_lexer(input, "test");
+    Parser parser(std::move(lexer));
+    auto program = parser.parse();
+    auto typed = TypeChecker{}(program);
+    return Zonker{}(std::move(typed));
+  }
+
+  static bool is_concrete(const hir::TypeRegistry &registry, hir::TypeId id) {
+    return !std::holds_alternative<hir::TypeVariable>(registry.get(id));
+  }
+
+  // --- Unifier state is consumed -------------------------------------------
+
+  TEST_CASE("zonked program has no unifier state") {
+    auto program = zonk_string("fn main() -> i64 { 42 }");
+    CHECK_FALSE(program.m_unifier_state.has_value());
+  }
+
+  // --- No type variables survive -------------------------------------------
+
+  TEST_CASE("function def types are concrete after zonking") {
+    auto program = zonk_string("fn main() -> i64 { 42 }");
+    REQUIRE(program.m_top_items.size() == 1);
+    auto &func = std::get<hir::FunctionDef>(program.m_top_items[0]);
+    CHECK(is_concrete(program.m_type_registry, func.m_type));
+    CHECK(is_concrete(program.m_type_registry, func.m_body.m_type));
+  }
+
+  TEST_CASE("let binding types are concrete after zonking") {
+    auto program = zonk_string("fn main() -> i64 {\n"
+                               "  let x: i64 = 10;\n"
+                               "  x\n"
+                               "}");
+    REQUIRE(program.m_top_items.size() == 1);
+    auto &func = std::get<hir::FunctionDef>(program.m_top_items[0]);
+    REQUIRE(!func.m_body.m_statements.empty());
+    auto &let = std::get<hir::LetBinding>(func.m_body.m_statements[0]);
+    CHECK(is_concrete(program.m_type_registry, let.m_variable.m_type));
+    CHECK(is_concrete(program.m_type_registry, let.m_expression.m_type));
+  }
+
+  TEST_CASE("lambda with inferred parameter type is concrete after zonking") {
+    auto program = zonk_string("fn main() -> i64 {\n"
+                               "  let add_one = |x| { x + 1 };\n"
+                               "  add_one(41)\n"
+                               "}");
+    REQUIRE(program.m_top_items.size() == 1);
+    auto &func = std::get<hir::FunctionDef>(program.m_top_items[0]);
+
+    // The let binding should have the lambda
+    REQUIRE(!func.m_body.m_statements.empty());
+    auto &let = std::get<hir::LetBinding>(func.m_body.m_statements[0]);
+    CHECK(is_concrete(program.m_type_registry, let.m_variable.m_type));
+    CHECK(is_concrete(program.m_type_registry, let.m_expression.m_type));
+
+    // The lambda's function type should be concrete
+    auto &lambda_expr = let.m_expression;
+    auto &lambda =
+        std::get<std::unique_ptr<hir::LambdaExpr>>(lambda_expr.m_expression);
+    for (const auto &param : lambda->m_parameters) {
+      CHECK(is_concrete(program.m_type_registry, param.m_type));
+    }
+    CHECK(is_concrete(program.m_type_registry, lambda->m_return_type));
+  }
+
+  // --- Resolved types are correct ------------------------------------------
+
+  TEST_CASE("inferred lambda parameter resolves to correct type") {
+    auto program = zonk_string("fn main() -> i64 {\n"
+                               "  let add_one = |x| { x + 1 };\n"
+                               "  add_one(41)\n"
+                               "}");
+    REQUIRE(program.m_top_items.size() == 1);
+    auto &func = std::get<hir::FunctionDef>(program.m_top_items[0]);
+    REQUIRE(!func.m_body.m_statements.empty());
+    auto &let = std::get<hir::LetBinding>(func.m_body.m_statements[0]);
+    auto &lambda = std::get<std::unique_ptr<hir::LambdaExpr>>(
+        let.m_expression.m_expression);
+
+    REQUIRE(lambda->m_parameters.size() == 1);
+    auto &param_type =
+        program.m_type_registry.get(lambda->m_parameters[0].m_type);
+    REQUIRE(std::holds_alternative<hir::PrimitiveTypeValue>(param_type));
+    CHECK(std::get<hir::PrimitiveTypeValue>(param_type).m_type ==
+          PrimitiveType::I64);
+  }
+
+} // TEST_SUITE
+//****************************************************************************
+} // namespace bust
+//****************************************************************************

--- a/bust/zonk/context.hpp
+++ b/bust/zonk/context.hpp
@@ -1,26 +1,23 @@
 //**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
 //*
 //*
-//*  Purpose : Top-level item zonker — resolves all type variables in
-//*            HIR top-level items to their concrete types.
+//*  Purpose : Shared context for the zonk pass.
 //*
 //*
 //****************************************************************************
 #pragma once
 //****************************************************************************
 
-#include <hir/nodes.hpp>
-#include <zonk/context.hpp>
+#include <hir/type_registry.hpp>
+#include <hir/unifier_state.hpp>
 
 //****************************************************************************
 namespace bust::zonk {
 //****************************************************************************
 
-struct TopItemZonker {
-  hir::TopItem operator()(hir::FunctionDef);
-  hir::TopItem operator()(hir::LetBinding);
-
-  Context &m_ctx;
+struct Context {
+  hir::TypeRegistry &m_type_registry;
+  hir::UnifierState &m_unifier_state;
 };
 
 //****************************************************************************

--- a/bust/zonk/context.hpp
+++ b/bust/zonk/context.hpp
@@ -9,15 +9,27 @@
 //****************************************************************************
 
 #include <hir/type_registry.hpp>
-#include <hir/unifier_state.hpp>
+#include <zonk/type_resolver.hpp>
 
 //****************************************************************************
 namespace bust::zonk {
 //****************************************************************************
 
 struct Context {
+  hir::TypeId reregister(hir::TypeId old_type_id) {
+    const auto &old_type = m_type_registry.get(old_type_id);
+    auto new_type_id = m_new_type_registry.intern(old_type);
+    return new_type_id;
+  }
+
+  hir::TypeId find_and_register(hir::TypeId old_type_id) {
+    auto resolved_type_id = m_resolver.resolve(old_type_id);
+    return reregister(resolved_type_id);
+  }
+
   hir::TypeRegistry &m_type_registry;
-  hir::UnifierState &m_unifier_state;
+  TypeResolver m_resolver;
+  hir::TypeRegistry m_new_type_registry{};
 };
 
 //****************************************************************************

--- a/bust/zonk/expression_zonker.cpp
+++ b/bust/zonk/expression_zonker.cpp
@@ -1,0 +1,91 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Expression zonker implementation.
+//*
+//*
+//****************************************************************************
+
+#include <variant>
+#include <zonk/expression_zonker.hpp>
+
+//****************************************************************************
+namespace bust::zonk {
+//****************************************************************************
+
+hir::Expression ExpressionZonker::zonk(hir::Expression expression) {
+  // TODO: Resolve expression.m_type, then visit the inner ExprKind
+  auto zonked_kind = std::visit(*this, std::move(expression.m_expression));
+  return {{expression.m_location}, expression.m_type, std::move(zonked_kind)};
+}
+
+hir::ExprKind ExpressionZonker::operator()(hir::Identifier identifier) {
+  return identifier;
+}
+
+hir::ExprKind ExpressionZonker::operator()(hir::LiteralUnit literal) {
+  return literal;
+}
+
+hir::ExprKind ExpressionZonker::operator()(hir::LiteralI8 literal) {
+  return literal;
+}
+
+hir::ExprKind ExpressionZonker::operator()(hir::LiteralI32 literal) {
+  return literal;
+}
+
+hir::ExprKind ExpressionZonker::operator()(hir::LiteralI64 literal) {
+  return literal;
+}
+
+hir::ExprKind ExpressionZonker::operator()(hir::LiteralBool literal) {
+  return literal;
+}
+
+hir::ExprKind ExpressionZonker::operator()(hir::LiteralChar literal) {
+  return literal;
+}
+
+hir::ExprKind ExpressionZonker::operator()(std::unique_ptr<hir::Block> block) {
+  return std::move(block);
+}
+
+hir::ExprKind
+ExpressionZonker::operator()(std::unique_ptr<hir::IfExpr> if_expr) {
+  return std::move(if_expr);
+}
+
+hir::ExprKind
+ExpressionZonker::operator()(std::unique_ptr<hir::CallExpr> call_expr) {
+  return std::move(call_expr);
+}
+
+hir::ExprKind
+ExpressionZonker::operator()(std::unique_ptr<hir::BinaryExpr> binary_expr) {
+  return std::move(binary_expr);
+}
+
+hir::ExprKind
+ExpressionZonker::operator()(std::unique_ptr<hir::UnaryExpr> unary_expr) {
+  return std::move(unary_expr);
+}
+
+hir::ExprKind
+ExpressionZonker::operator()(std::unique_ptr<hir::ReturnExpr> return_expr) {
+  return std::move(return_expr);
+}
+
+hir::ExprKind
+ExpressionZonker::operator()(std::unique_ptr<hir::CastExpr> cast_expr) {
+  return std::move(cast_expr);
+}
+
+hir::ExprKind
+ExpressionZonker::operator()(std::unique_ptr<hir::LambdaExpr> lambda_expr) {
+  return std::move(lambda_expr);
+}
+
+//****************************************************************************
+} // namespace bust::zonk
+//****************************************************************************

--- a/bust/zonk/expression_zonker.cpp
+++ b/bust/zonk/expression_zonker.cpp
@@ -6,6 +6,10 @@
 //*
 //****************************************************************************
 
+#include "hir/nodes.hpp"
+#include "zonk/statement_zonker.hpp"
+#include <memory>
+#include <optional>
 #include <variant>
 #include <zonk/expression_zonker.hpp>
 
@@ -16,11 +20,23 @@ namespace bust::zonk {
 hir::Expression ExpressionZonker::zonk(hir::Expression expression) {
   // TODO: Resolve expression.m_type, then visit the inner ExprKind
   auto zonked_kind = std::visit(*this, std::move(expression.m_expression));
-  return {{expression.m_location}, expression.m_type, std::move(zonked_kind)};
+
+  auto new_type_id = m_ctx.find_and_register(expression.m_type);
+
+  return {{expression.m_location}, new_type_id, std::move(zonked_kind)};
+}
+
+hir::ExprKind ExpressionZonker::zonk(hir::Block block) {
+  return std::make_unique<hir::Block>(zonk_block(std::move(block)));
+}
+
+hir::Identifier ExpressionZonker::zonk(hir::Identifier identifier) {
+  auto new_type_id = m_ctx.find_and_register(identifier.m_type);
+  return {{identifier.m_location}, std::move(identifier.m_name), new_type_id};
 }
 
 hir::ExprKind ExpressionZonker::operator()(hir::Identifier identifier) {
-  return identifier;
+  return zonk(std::move(identifier));
 }
 
 hir::ExprKind ExpressionZonker::operator()(hir::LiteralUnit literal) {
@@ -47,43 +63,115 @@ hir::ExprKind ExpressionZonker::operator()(hir::LiteralChar literal) {
   return literal;
 }
 
-hir::ExprKind ExpressionZonker::operator()(std::unique_ptr<hir::Block> block) {
-  return std::move(block);
+hir::ExprKind
+ExpressionZonker::operator()(std::unique_ptr<hir::Block> block_ptr) {
+  auto &block = *block_ptr;
+  return zonk(std::move(block));
+}
+
+hir::Block ExpressionZonker::zonk_block(hir::Block block) {
+  std::vector<hir::Statement> zonked_statements;
+  zonked_statements.reserve(block.m_statements.size());
+  for (auto &statement : block.m_statements) {
+    auto zonked_statement = StatementZonker{m_ctx}.zonk(std::move(statement));
+    zonked_statements.push_back(std::move(zonked_statement));
+  }
+
+  auto zonked_final_expression =
+      block.m_final_expression.has_value()
+          ? std::optional<hir::Expression>(
+                zonk(std::move(block.m_final_expression.value())))
+          : std::nullopt;
+
+  auto new_type_id = m_ctx.find_and_register(block.m_type);
+
+  return {{block.m_location},
+          new_type_id,
+          std::move(zonked_statements),
+          std::move(zonked_final_expression)};
 }
 
 hir::ExprKind
 ExpressionZonker::operator()(std::unique_ptr<hir::IfExpr> if_expr) {
-  return std::move(if_expr);
+  auto zonked_condition = zonk(std::move(if_expr->m_condition));
+
+  auto zonked_then_block = zonk_block(std::move(if_expr->m_then_block));
+
+  auto zonked_else_block = if_expr->m_else_block.has_value()
+                               ? std::optional<hir::Block>(zonk_block(
+                                     std::move(if_expr->m_else_block.value())))
+                               : std::nullopt;
+
+  return std::make_unique<hir::IfExpr>(
+      hir::IfExpr{std::move(zonked_condition), std::move(zonked_then_block),
+                  std::move(zonked_else_block)});
 }
 
 hir::ExprKind
 ExpressionZonker::operator()(std::unique_ptr<hir::CallExpr> call_expr) {
-  return std::move(call_expr);
+  auto zonked_callee = zonk(std::move(call_expr->m_callee));
+
+  std::vector<hir::Expression> zonked_arguments;
+  zonked_arguments.reserve(call_expr->m_arguments.size());
+  for (auto &argument : call_expr->m_arguments) {
+    zonked_arguments.push_back(zonk(std::move(argument)));
+  }
+
+  return std::make_unique<hir::CallExpr>(
+      hir::CallExpr{std::move(zonked_callee), std::move(zonked_arguments)});
 }
 
 hir::ExprKind
 ExpressionZonker::operator()(std::unique_ptr<hir::BinaryExpr> binary_expr) {
-  return std::move(binary_expr);
+  auto zonked_lhs = zonk(std::move(binary_expr->m_lhs));
+  auto zonked_rhs = zonk(std::move(binary_expr->m_rhs));
+
+  return std::make_unique<hir::BinaryExpr>(hir::BinaryExpr{
+      binary_expr->m_operator, std::move(zonked_lhs), std::move(zonked_rhs)});
 }
 
 hir::ExprKind
 ExpressionZonker::operator()(std::unique_ptr<hir::UnaryExpr> unary_expr) {
-  return std::move(unary_expr);
+  auto zonked_expression = zonk(std::move(unary_expr->m_expression));
+
+  return std::make_unique<hir::UnaryExpr>(
+      hir::UnaryExpr{unary_expr->m_operator, std::move(zonked_expression)});
 }
 
 hir::ExprKind
 ExpressionZonker::operator()(std::unique_ptr<hir::ReturnExpr> return_expr) {
-  return std::move(return_expr);
+  auto zonked_expression = zonk(std::move(return_expr->m_expression));
+
+  return std::make_unique<hir::ReturnExpr>(
+      hir::ReturnExpr{std::move(zonked_expression)});
 }
 
 hir::ExprKind
 ExpressionZonker::operator()(std::unique_ptr<hir::CastExpr> cast_expr) {
-  return std::move(cast_expr);
+  auto zonked_expression = zonk(std::move(cast_expr->m_expression));
+
+  auto zonked_new_type_id = m_ctx.find_and_register(cast_expr->m_new_type);
+
+  return std::make_unique<hir::CastExpr>(
+      hir::CastExpr{std::move(zonked_expression), zonked_new_type_id});
 }
 
 hir::ExprKind
 ExpressionZonker::operator()(std::unique_ptr<hir::LambdaExpr> lambda_expr) {
-  return std::move(lambda_expr);
+  std::vector<hir::Identifier> zonked_parameters;
+  zonked_parameters.reserve(lambda_expr->m_parameters.size());
+  for (auto &parameter : lambda_expr->m_parameters) {
+    zonked_parameters.push_back(zonk(std::move(parameter)));
+  }
+
+  auto zonked_body = zonk_block(std::move(lambda_expr->m_body));
+
+  auto zonked_return_type_id =
+      m_ctx.find_and_register(lambda_expr->m_return_type);
+
+  return std::make_unique<hir::LambdaExpr>(
+      hir::LambdaExpr{std::move(zonked_parameters), std::move(zonked_body),
+                      zonked_return_type_id});
 }
 
 //****************************************************************************

--- a/bust/zonk/expression_zonker.hpp
+++ b/bust/zonk/expression_zonker.hpp
@@ -1,0 +1,44 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Expression zonker — resolves all type variables in
+//*            HIR expressions to their concrete types.
+//*
+//*
+//****************************************************************************
+#pragma once
+//****************************************************************************
+
+#include <hir/nodes.hpp>
+#include <memory>
+#include <zonk/context.hpp>
+
+//****************************************************************************
+namespace bust::zonk {
+//****************************************************************************
+
+struct ExpressionZonker {
+  hir::Expression zonk(hir::Expression);
+
+  hir::ExprKind operator()(hir::Identifier);
+  hir::ExprKind operator()(hir::LiteralUnit);
+  hir::ExprKind operator()(hir::LiteralI8);
+  hir::ExprKind operator()(hir::LiteralI32);
+  hir::ExprKind operator()(hir::LiteralI64);
+  hir::ExprKind operator()(hir::LiteralBool);
+  hir::ExprKind operator()(hir::LiteralChar);
+  hir::ExprKind operator()(std::unique_ptr<hir::Block>);
+  hir::ExprKind operator()(std::unique_ptr<hir::IfExpr>);
+  hir::ExprKind operator()(std::unique_ptr<hir::CallExpr>);
+  hir::ExprKind operator()(std::unique_ptr<hir::BinaryExpr>);
+  hir::ExprKind operator()(std::unique_ptr<hir::UnaryExpr>);
+  hir::ExprKind operator()(std::unique_ptr<hir::ReturnExpr>);
+  hir::ExprKind operator()(std::unique_ptr<hir::CastExpr>);
+  hir::ExprKind operator()(std::unique_ptr<hir::LambdaExpr>);
+
+  Context &m_ctx;
+};
+
+//****************************************************************************
+} // namespace bust::zonk
+//****************************************************************************

--- a/bust/zonk/expression_zonker.hpp
+++ b/bust/zonk/expression_zonker.hpp
@@ -20,6 +20,9 @@ namespace bust::zonk {
 struct ExpressionZonker {
   hir::Expression zonk(hir::Expression);
 
+  hir::ExprKind zonk(hir::Block);
+
+  hir::Identifier zonk(hir::Identifier);
   hir::ExprKind operator()(hir::Identifier);
   hir::ExprKind operator()(hir::LiteralUnit);
   hir::ExprKind operator()(hir::LiteralI8);
@@ -28,6 +31,7 @@ struct ExpressionZonker {
   hir::ExprKind operator()(hir::LiteralBool);
   hir::ExprKind operator()(hir::LiteralChar);
   hir::ExprKind operator()(std::unique_ptr<hir::Block>);
+  hir::Block zonk_block(hir::Block);
   hir::ExprKind operator()(std::unique_ptr<hir::IfExpr>);
   hir::ExprKind operator()(std::unique_ptr<hir::CallExpr>);
   hir::ExprKind operator()(std::unique_ptr<hir::BinaryExpr>);

--- a/bust/zonk/let_binding_zonker.cpp
+++ b/bust/zonk/let_binding_zonker.cpp
@@ -6,6 +6,7 @@
 //*
 //****************************************************************************
 
+#include "zonk/expression_zonker.hpp"
 #include <zonk/let_binding_zonker.hpp>
 
 //****************************************************************************
@@ -13,8 +14,18 @@ namespace bust::zonk {
 //****************************************************************************
 
 hir::LetBinding LetBindingZonker::zonk(hir::LetBinding let_binding) {
-  // TODO: Zonk the variable's type and the expression
-  return let_binding;
+  auto zonker = ExpressionZonker{m_ctx};
+
+  auto zonked_expression = zonker.zonk(std::move(let_binding.m_expression));
+
+  auto zonked_identifier_expression = zonker(std::move(let_binding.m_variable));
+
+  auto &zonked_identifier =
+      std::get<hir::Identifier>(zonked_identifier_expression);
+
+  return hir::LetBinding{{let_binding.m_location},
+                         std::move(zonked_identifier),
+                         std::move(zonked_expression)};
 }
 
 //****************************************************************************

--- a/bust/zonk/let_binding_zonker.cpp
+++ b/bust/zonk/let_binding_zonker.cpp
@@ -1,0 +1,22 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Let binding zonker implementation.
+//*
+//*
+//****************************************************************************
+
+#include <zonk/let_binding_zonker.hpp>
+
+//****************************************************************************
+namespace bust::zonk {
+//****************************************************************************
+
+hir::LetBinding LetBindingZonker::zonk(hir::LetBinding let_binding) {
+  // TODO: Zonk the variable's type and the expression
+  return let_binding;
+}
+
+//****************************************************************************
+} // namespace bust::zonk
+//****************************************************************************

--- a/bust/zonk/let_binding_zonker.hpp
+++ b/bust/zonk/let_binding_zonker.hpp
@@ -1,0 +1,27 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Let binding zonker — resolves all type variables in
+//*            HIR let bindings to their concrete types.
+//*
+//*
+//****************************************************************************
+#pragma once
+//****************************************************************************
+
+#include <hir/nodes.hpp>
+#include <zonk/context.hpp>
+
+//****************************************************************************
+namespace bust::zonk {
+//****************************************************************************
+
+struct LetBindingZonker {
+  hir::LetBinding zonk(hir::LetBinding);
+
+  Context &m_ctx;
+};
+
+//****************************************************************************
+} // namespace bust::zonk
+//****************************************************************************

--- a/bust/zonk/statement_zonker.cpp
+++ b/bust/zonk/statement_zonker.cpp
@@ -1,0 +1,30 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Statement zonker implementation.
+//*
+//*
+//****************************************************************************
+
+#include <variant>
+#include <zonk/statement_zonker.hpp>
+
+//****************************************************************************
+namespace bust::zonk {
+//****************************************************************************
+
+hir::Statement StatementZonker::zonk(hir::Statement statement) {
+  return std::visit(*this, std::move(statement));
+}
+
+hir::Statement StatementZonker::operator()(hir::Expression expression) {
+  return expression;
+}
+
+hir::Statement StatementZonker::operator()(hir::LetBinding let_binding) {
+  return let_binding;
+}
+
+//****************************************************************************
+} // namespace bust::zonk
+//****************************************************************************

--- a/bust/zonk/statement_zonker.cpp
+++ b/bust/zonk/statement_zonker.cpp
@@ -6,6 +6,8 @@
 //*
 //****************************************************************************
 
+#include "zonk/expression_zonker.hpp"
+#include "zonk/let_binding_zonker.hpp"
 #include <variant>
 #include <zonk/statement_zonker.hpp>
 
@@ -18,11 +20,11 @@ hir::Statement StatementZonker::zonk(hir::Statement statement) {
 }
 
 hir::Statement StatementZonker::operator()(hir::Expression expression) {
-  return expression;
+  return ExpressionZonker{m_ctx}.zonk(std::move(expression));
 }
 
 hir::Statement StatementZonker::operator()(hir::LetBinding let_binding) {
-  return let_binding;
+  return LetBindingZonker{m_ctx}.zonk(std::move(let_binding));
 }
 
 //****************************************************************************

--- a/bust/zonk/statement_zonker.hpp
+++ b/bust/zonk/statement_zonker.hpp
@@ -1,0 +1,30 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Statement zonker — resolves all type variables in
+//*            HIR statements to their concrete types.
+//*
+//*
+//****************************************************************************
+#pragma once
+//****************************************************************************
+
+#include <hir/nodes.hpp>
+#include <zonk/context.hpp>
+
+//****************************************************************************
+namespace bust::zonk {
+//****************************************************************************
+
+struct StatementZonker {
+  hir::Statement zonk(hir::Statement);
+
+  hir::Statement operator()(hir::Expression);
+  hir::Statement operator()(hir::LetBinding);
+
+  Context &m_ctx;
+};
+
+//****************************************************************************
+} // namespace bust::zonk
+//****************************************************************************

--- a/bust/zonk/top_item_zonker.cpp
+++ b/bust/zonk/top_item_zonker.cpp
@@ -6,21 +6,62 @@
 //*
 //****************************************************************************
 
+#include "exceptions.hpp"
+#include "hir/nodes.hpp"
+#include "zonk/expression_zonker.hpp"
+#include "zonk/let_binding_zonker.hpp"
+#include <variant>
 #include <zonk/top_item_zonker.hpp>
 
 //****************************************************************************
 namespace bust::zonk {
 //****************************************************************************
 
+hir::TopItem TopItemZonker::zonk(hir::TopItem top_item) {
+  return std::visit(*this, std::move(top_item));
+}
+
 hir::TopItem TopItemZonker::operator()(hir::FunctionDef function_def) {
-  // TODO: Deep-resolve all TypeIds in the function definition,
-  // replacing any that point to TypeVariables with their concrete types.
-  return function_def;
+  auto zonker = ExpressionZonker{m_ctx};
+
+  // For now, we expect top level functions to have annotated parameters and
+  // return types
+  std::vector<hir::Identifier> zonked_parameters;
+  zonked_parameters.reserve(function_def.m_parameters.size());
+  std::vector<hir::TypeId> zonked_parameter_ids;
+  zonked_parameter_ids.reserve(function_def.m_parameters.size());
+  for (auto &parameter : function_def.m_parameters) {
+    auto zonked_expression = zonker(std::move(parameter));
+    if (!std::holds_alternative<hir::Identifier>(zonked_expression)) {
+      throw core::InternalCompilerError("Bad expression visitor");
+    }
+    auto &zonked_parameter = std::get<hir::Identifier>(zonked_expression);
+    zonked_parameter_ids.push_back(zonked_parameter.m_type);
+    zonked_parameters.push_back(std::move(zonked_parameter));
+  }
+
+  // Insert the return value into the new type registry
+  auto zonked_return_type_id = m_ctx.find_and_register(function_def.m_type);
+
+  // Reconstruct the zonked function type
+  auto zonked_function_type =
+      hir::FunctionType{.m_parameters = std::move(zonked_parameter_ids),
+                        .m_return_type = zonked_return_type_id};
+  auto zonked_function_type_id =
+      m_ctx.m_new_type_registry.intern(zonked_function_type);
+
+  // Zonk the body
+  auto zonked_body = zonker.zonk_block(std::move(function_def.m_body));
+
+  return hir::FunctionDef{{function_def.m_location},
+                          std::move(function_def.m_function_id),
+                          zonked_function_type_id,
+                          std::move(zonked_parameters),
+                          std::move(zonked_body)};
 }
 
 hir::TopItem TopItemZonker::operator()(hir::LetBinding let_binding) {
-  // TODO: Deep-resolve all TypeIds in the let binding.
-  return let_binding;
+  return LetBindingZonker{m_ctx}.zonk(std::move(let_binding));
 }
 
 //****************************************************************************

--- a/bust/zonk/top_item_zonker.cpp
+++ b/bust/zonk/top_item_zonker.cpp
@@ -1,0 +1,28 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Top-level item zonker implementation.
+//*
+//*
+//****************************************************************************
+
+#include <zonk/top_item_zonker.hpp>
+
+//****************************************************************************
+namespace bust::zonk {
+//****************************************************************************
+
+hir::TopItem TopItemZonker::operator()(hir::FunctionDef function_def) {
+  // TODO: Deep-resolve all TypeIds in the function definition,
+  // replacing any that point to TypeVariables with their concrete types.
+  return function_def;
+}
+
+hir::TopItem TopItemZonker::operator()(hir::LetBinding let_binding) {
+  // TODO: Deep-resolve all TypeIds in the let binding.
+  return let_binding;
+}
+
+//****************************************************************************
+} // namespace bust::zonk
+//****************************************************************************

--- a/bust/zonk/top_item_zonker.hpp
+++ b/bust/zonk/top_item_zonker.hpp
@@ -17,6 +17,9 @@ namespace bust::zonk {
 //****************************************************************************
 
 struct TopItemZonker {
+
+  hir::TopItem zonk(hir::TopItem);
+
   hir::TopItem operator()(hir::FunctionDef);
   hir::TopItem operator()(hir::LetBinding);
 

--- a/bust/zonk/top_item_zonker.hpp
+++ b/bust/zonk/top_item_zonker.hpp
@@ -1,0 +1,30 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Top-level item zonker — resolves all type variables in
+//*            HIR top-level items to their concrete types.
+//*
+//*
+//****************************************************************************
+#pragma once
+//****************************************************************************
+
+#include <hir/nodes.hpp>
+#include <hir/type_registry.hpp>
+#include <hir/unifier_state.hpp>
+
+//****************************************************************************
+namespace bust::zonk {
+//****************************************************************************
+
+struct TopItemZonker {
+  hir::TopItem operator()(hir::FunctionDef);
+  hir::TopItem operator()(hir::LetBinding);
+
+  hir::TypeRegistry &m_type_registry;
+  hir::UnifierState &m_unifier_state;
+};
+
+//****************************************************************************
+} // namespace bust::zonk
+//****************************************************************************

--- a/bust/zonk/type_resolver.hpp
+++ b/bust/zonk/type_resolver.hpp
@@ -1,0 +1,46 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Post-inference type resolver — wraps unifier state to
+//*            provide find-only access for the zonk pass.
+//*
+//*
+//****************************************************************************
+#pragma once
+//****************************************************************************
+
+#include <hir/type_registry.hpp>
+#include <hir/types.hpp>
+#include <hir/unifier_state.hpp>
+#include <variant>
+
+//****************************************************************************
+namespace bust::zonk {
+//****************************************************************************
+
+struct TypeResolver {
+  hir::TypeId resolve(hir::TypeId type_id) {
+    const auto &type = m_type_registry.get(type_id);
+    if (!std::holds_alternative<hir::TypeVariable>(type)) {
+      return type_id;
+    }
+
+    auto root = m_unifier_state.m_union_find.find(
+        std::get<hir::TypeVariable>(type).m_id);
+
+    auto iter = m_unifier_state.m_resolved_type_id.find(root);
+    if (iter != m_unifier_state.m_resolved_type_id.end()) {
+      return iter->second;
+    }
+
+    // Type variable was not resolved to a concrete type
+    return type_id;
+  }
+
+  hir::TypeRegistry &m_type_registry;
+  hir::UnifierState m_unifier_state;
+};
+
+//****************************************************************************
+} // namespace bust::zonk
+//****************************************************************************

--- a/bust/zonk/type_resolver.hpp
+++ b/bust/zonk/type_resolver.hpp
@@ -9,6 +9,7 @@
 #pragma once
 //****************************************************************************
 
+#include "exceptions.hpp"
 #include <hir/type_registry.hpp>
 #include <hir/types.hpp>
 #include <hir/unifier_state.hpp>
@@ -34,7 +35,10 @@ struct TypeResolver {
     }
 
     // Type variable was not resolved to a concrete type
-    return type_id;
+    throw core::InternalCompilerError(
+        "We assume all type variables should "
+        "have been resolved before zonking!\nCould not resolve: " +
+        m_type_registry.to_string(type_id));
   }
 
   hir::TypeRegistry &m_type_registry;


### PR DESCRIPTION
Basically just a pass to completely rebuild the hir nodes with all type variables resolved to concrete types. Clean up the registry by making it purely contain concrete types. Could force this with compiler at some point by adding new type variant. Could also break this with type system changes if we ever wanted to allow polymorphic functions at the top level