### PR TITLE
Some more type system fixes

### DIFF
--- a/bust/hir/context.hpp
+++ b/bust/hir/context.hpp
@@ -23,7 +23,10 @@ struct Context {
   TypeId create_fresh_type_vars(const TypeScheme &type_scheme) {
     std::unordered_map<TypeVariable, TypeVariable> new_mapping;
     for (const auto &old_type_variable : type_scheme.m_free_type_variables) {
-      new_mapping.emplace(old_type_variable, m_type_unifier.new_type_var());
+      auto possible_type_class =
+          m_type_unifier.find_type_class(old_type_variable);
+      new_mapping.emplace(old_type_variable,
+                          m_type_unifier.new_type_var(possible_type_class));
     }
 
     return TypeVariableUpdater{m_type_registry, new_mapping}.update(

--- a/bust/hir/context.hpp
+++ b/bust/hir/context.hpp
@@ -11,7 +11,7 @@
 #include "hir/type_registry.hpp"
 #include <hir/environment.hpp>
 #include <hir/type_unifier.hpp>
-#include <hir/type_visitors.hpp>
+#include <hir/type_variable_updater.hpp>
 #include <vector>
 
 //****************************************************************************

--- a/bust/hir/dump.hpp
+++ b/bust/hir/dump.hpp
@@ -21,14 +21,17 @@ namespace bust::hir {
 class Dumper {
 public:
   static std::string dump(const Program &program) {
-    Dumper d;
+    Dumper d(program);
     d.dump_program(program);
     return d.m_out.str();
   }
 
 private:
+  const Program &m_program;
   std::ostringstream m_out;
   int m_indent = 0;
+
+  Dumper(const Program &program) : m_program(program) {}
 
   void indent() {
     for (int i = 0; i < m_indent; ++i) {
@@ -68,30 +71,26 @@ private:
         item);
   }
 
-  void dump_identifier(const Identifier & // id
-  ) {
-    // m_out << id.m_name << ": " << type_to_string(id.m_type);
+  void dump_identifier(const Identifier &id) {
+    m_out << id.m_name << ": "
+          << m_program.m_type_registry.to_string(id.m_type);
   }
 
-  void dump_func_def(const FunctionDef & // f
-  ) {
-    // indent();
-    // m_out << "FunctionDef " << f.m_function_id << ": "
-    //       << type_to_string(Type(
-    //              std::make_shared<FunctionTypePtr::element_type>(FunctionType{
-    //                  f.m_type->m_argument_types, f.m_type->m_return_type})))
-    //       << "\n";
-    // IndentGuard g(*this);
-    // indent();
-    // m_out << "params(";
-    // for (size_t i = 0; i < f.m_parameters.size(); ++i) {
-    //   if (i > 0) {
-    //     m_out << ", ";
-    //   }
-    //   dump_identifier(f.m_parameters[i]);
-    // }
-    // m_out << ")\n";
-    // dump_block(f.m_body);
+  void dump_func_def(const FunctionDef &f) {
+    indent();
+    m_out << "FunctionDef " << f.m_function_id << ": "
+          << m_program.m_type_registry.to_string(f.m_type) << "\n";
+    IndentGuard g(*this);
+    indent();
+    m_out << "params(";
+    for (size_t i = 0; i < f.m_parameters.size(); ++i) {
+      if (i > 0) {
+        m_out << ", ";
+      }
+      dump_identifier(f.m_parameters[i]);
+    }
+    m_out << ")\n";
+    dump_block(f.m_body);
   }
 
   void dump_let_binding(const LetBinding &lb) {
@@ -129,97 +128,91 @@ private:
         s);
   }
 
-  void dump_expression(const Expression & // e
-  ) {
-    // indent();
-    // m_out << "[" << type_to_string(e.m_type) << "] ";
-    // // Reset indent for the inner content since we already indented
-    // std::visit(
-    //     [this](const auto &v) {
-    //       using T = std::decay_t<decltype(v)>;
-    //       if constexpr (std::is_same_v<T, Identifier>) {
-    //         m_out << "Ident(" << v.m_name << ")\n";
-    //       } else if constexpr (std::is_same_v<T, LiteralI64>) {
-    //         m_out << "Int(" << v.m_value << ")\n";
-    //       } else if constexpr (std::is_same_v<T, LiteralBool>) {
-    //         m_out << "Bool(" << (v.m_value ? "true" : "false") << ")\n";
-    //       } else if constexpr (std::is_same_v<T, LiteralUnit>) {
-    //         m_out << "Unit\n";
-    //       } else if constexpr (std::is_same_v<T,
-    //       std::unique_ptr<BinaryExpr>>) {
-    //         m_out << "Binary(" << v->m_operator << ")\n";
-    //         IndentGuard g(*this);
-    //         dump_expression(v->m_lhs);
-    //         dump_expression(v->m_rhs);
-    //       } else if constexpr (std::is_same_v<T, std::unique_ptr<UnaryExpr>>)
-    //       {
-    //         m_out << "Unary(" << v->m_operator << ")\n";
-    //         IndentGuard g(*this);
-    //         dump_expression(v->m_expression);
-    //       } else if constexpr (std::is_same_v<T, std::unique_ptr<CallExpr>>)
-    //       {
-    //         m_out << "Call\n";
-    //         IndentGuard g(*this);
-    //         line("callee:");
-    //         {
-    //           IndentGuard g2(*this);
-    //           dump_expression(v->m_callee);
-    //         }
-    //         if (!v->m_arguments.empty()) {
-    //           line("args:");
-    //           IndentGuard g2(*this);
-    //           for (const auto &arg : v->m_arguments) {
-    //             dump_expression(arg);
-    //           }
-    //         }
-    //       } else if constexpr (std::is_same_v<T, std::unique_ptr<IfExpr>>) {
-    //         m_out << "If\n";
-    //         IndentGuard g(*this);
-    //         line("cond:");
-    //         {
-    //           IndentGuard g2(*this);
-    //           dump_expression(v->m_condition);
-    //         }
-    //         line("then:");
-    //         {
-    //           IndentGuard g2(*this);
-    //           dump_block(v->m_then_block);
-    //         }
-    //         if (v->m_else_block.has_value()) {
-    //           line("else:");
-    //           IndentGuard g2(*this);
-    //           dump_block(*v->m_else_block);
-    //         }
-    //       } else if constexpr (std::is_same_v<T, std::unique_ptr<Block>>) {
-    //         m_out << "Block\n";
-    //         IndentGuard g(*this);
-    //         dump_block(*v);
-    //       } else if constexpr (std::is_same_v<T,
-    //       std::unique_ptr<ReturnExpr>>) {
-    //         m_out << "Return\n";
-    //         IndentGuard g(*this);
-    //         dump_expression(v->m_expression);
-    //       } else if constexpr (std::is_same_v<T, std::unique_ptr<CastExpr>>)
-    //       {
-    //         m_out << "Cast\n";
-    //         IndentGuard g(*this);
-    //         dump_expression(v->m_expression);
-    //         m_out << " AS " << type_to_string(v->m_new_type);
-    //       } else if constexpr (std::is_same_v<T,
-    //       std::unique_ptr<LambdaExpr>>) {
-    //         m_out << "Lambda(";
-    //         for (size_t i = 0; i < v->m_parameters.size(); ++i) {
-    //           if (i > 0) {
-    //             m_out << ", ";
-    //           }
-    //           dump_identifier(v->m_parameters[i]);
-    //         }
-    //         m_out << ")\n";
-    //         IndentGuard g(*this);
-    //         dump_block(v->m_body);
-    //       }
-    //     },
-    //     e.m_expression);
+  void dump_expression(const Expression &e) {
+    indent();
+    m_out << "[" << m_program.m_type_registry.to_string(e.m_type) << "] ";
+    // Reset indent for the inner content since we already indented
+    std::visit(
+        [this](const auto &v) {
+          using T = std::decay_t<decltype(v)>;
+          if constexpr (std::is_same_v<T, Identifier>) {
+            m_out << "Ident(" << v.m_name << ")\n";
+          } else if constexpr (std::is_same_v<T, LiteralI64>) {
+            m_out << "Int(" << v.m_value << ")\n";
+          } else if constexpr (std::is_same_v<T, LiteralBool>) {
+            m_out << "Bool(" << (v.m_value ? "true" : "false") << ")\n";
+          } else if constexpr (std::is_same_v<T, LiteralUnit>) {
+            m_out << "Unit\n";
+          } else if constexpr (std::is_same_v<T, std::unique_ptr<BinaryExpr>>) {
+            m_out << "Binary(" << v->m_operator << ")\n";
+            IndentGuard g(*this);
+            dump_expression(v->m_lhs);
+            dump_expression(v->m_rhs);
+          } else if constexpr (std::is_same_v<T, std::unique_ptr<UnaryExpr>>) {
+            m_out << "Unary(" << v->m_operator << ")\n";
+            IndentGuard g(*this);
+            dump_expression(v->m_expression);
+          } else if constexpr (std::is_same_v<T, std::unique_ptr<CallExpr>>) {
+            m_out << "Call\n";
+            IndentGuard g(*this);
+            line("callee:");
+            {
+              IndentGuard g2(*this);
+              dump_expression(v->m_callee);
+            }
+            if (!v->m_arguments.empty()) {
+              line("args:");
+              IndentGuard g2(*this);
+              for (const auto &arg : v->m_arguments) {
+                dump_expression(arg);
+              }
+            }
+          } else if constexpr (std::is_same_v<T, std::unique_ptr<IfExpr>>) {
+            m_out << "If\n";
+            IndentGuard g(*this);
+            line("cond:");
+            {
+              IndentGuard g2(*this);
+              dump_expression(v->m_condition);
+            }
+            line("then:");
+            {
+              IndentGuard g2(*this);
+              dump_block(v->m_then_block);
+            }
+            if (v->m_else_block.has_value()) {
+              line("else:");
+              IndentGuard g2(*this);
+              dump_block(*v->m_else_block);
+            }
+          } else if constexpr (std::is_same_v<T, std::unique_ptr<Block>>) {
+            m_out << "Block\n";
+            IndentGuard g(*this);
+            dump_block(*v);
+          } else if constexpr (std::is_same_v<T, std::unique_ptr<ReturnExpr>>) {
+            m_out << "Return\n";
+            IndentGuard g(*this);
+            dump_expression(v->m_expression);
+          } else if constexpr (std::is_same_v<T, std::unique_ptr<CastExpr>>) {
+            m_out << "Cast\n";
+            IndentGuard g(*this);
+            dump_expression(v->m_expression);
+            m_out << " AS "
+                  << m_program.m_type_registry.to_string(v->m_new_type);
+          } else if constexpr (std::is_same_v<T, std::unique_ptr<LambdaExpr>>) {
+            m_out << "Lambda(";
+            for (size_t i = 0; i < v->m_parameters.size(); ++i) {
+              if (i > 0) {
+                m_out << ", ";
+              }
+              dump_identifier(v->m_parameters[i]);
+            }
+            m_out << ")\n";
+            IndentGuard g(*this);
+            dump_block(v->m_body);
+          }
+        },
+        e.m_expression);
   }
 };
 

--- a/bust/hir/expression_checker.cpp
+++ b/bust/hir/expression_checker.cpp
@@ -428,38 +428,13 @@ Expression ExpressionChecker::operator()(
         location);
   }
 
-  // Do we need to rediscover the return type and body types?
-
-  // Expect body to have a unified type?
-  std::vector<Identifier> unified_parameters;
-  unified_parameters.reserve(parameters.size());
-  std::vector<TypeId> unified_parameter_types;
-  unified_parameter_types.reserve(parameter_types.size());
-  for (const auto &[parameter, parameter_type_id] :
-       std::views::zip(parameters, parameter_types)) {
-    const auto &parameter_type = m_ctx.m_type_registry.get(parameter_type_id);
-    if (!std::holds_alternative<TypeVariable>(parameter_type)) {
-      // TODO Could be more efficient than reconstructing
-      unified_parameters.emplace_back(Identifier{
-          {parameter.m_location}, parameter.m_name, parameter.m_type});
-      unified_parameter_types.push_back(parameter_type_id);
-      continue;
-    }
-    // See if we can resolve them
-    auto unified_type =
-        m_ctx.m_type_unifier.find(std::get<TypeVariable>(parameter_type));
-    unified_parameters.emplace_back(
-        Identifier{{parameter.m_location}, parameter.m_name, unified_type});
-    unified_parameter_types.push_back(unified_type);
-  }
-
   auto function_type_id = m_ctx.m_type_registry.intern(
-      FunctionType{std::move(unified_parameter_types), return_type_id});
+      FunctionType{std::move(parameter_types), return_type_id});
 
   return {{location},
           function_type_id,
           std::make_unique<LambdaExpr>(LambdaExpr{
-              std::move(unified_parameters), std::move(body), return_type_id})};
+              std::move(parameters), std::move(body), return_type_id})};
 }
 
 Expression

--- a/bust/hir/free_type_variable_collector.hpp
+++ b/bust/hir/free_type_variable_collector.hpp
@@ -25,10 +25,11 @@ struct FreeTypeVariableCollector {
   void operator()(const TypeVariable &type) {
     // Let's try to resolve the types first
     auto resolved_type_id = m_ctx.m_type_unifier.find(type);
-    if (std::holds_alternative<TypeVariable>(
+    if (!std::holds_alternative<TypeVariable>(
             m_ctx.m_type_registry.get(resolved_type_id))) {
-      m_free_type_variables.emplace_back(type);
+      return;
     }
+    m_free_type_variables.emplace_back(type);
   }
 
   void operator()(const FunctionType &type) {

--- a/bust/hir/free_type_variable_collector.hpp
+++ b/bust/hir/free_type_variable_collector.hpp
@@ -1,0 +1,50 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Free type variable collection visitor for bust HIR types.
+//*
+//*
+//****************************************************************************
+#pragma once
+//****************************************************************************
+
+#include <hir/context.hpp>
+#include <hir/types.hpp>
+
+//****************************************************************************
+namespace bust::hir {
+//****************************************************************************
+
+struct FreeTypeVariableCollector {
+
+  void collect(const TypeKind &type) { std::visit(*this, type); }
+  void collect(const TypeId &type) { collect(m_ctx.m_type_registry.get(type)); }
+
+  void operator()(const PrimitiveTypeValue &) {}
+
+  void operator()(const TypeVariable &type) {
+    // Let's try to resolve the types first
+    auto resolved_type_id = m_ctx.m_type_unifier.find(type);
+    if (std::holds_alternative<TypeVariable>(
+            m_ctx.m_type_registry.get(resolved_type_id))) {
+      m_free_type_variables.emplace_back(type);
+    }
+  }
+
+  void operator()(const FunctionType &type) {
+    for (const auto &parameter : type.m_parameters) {
+      collect(m_ctx.m_type_registry.get(parameter));
+    }
+
+    collect(m_ctx.m_type_registry.get(type.m_return_type));
+  }
+
+  void operator()(const NeverType &) {}
+
+  hir::Context &m_ctx;
+  std::vector<TypeVariable> m_free_type_variables{};
+};
+
+//****************************************************************************
+} // namespace bust::hir
+//****************************************************************************

--- a/bust/hir/let_binding_checker.cpp
+++ b/bust/hir/let_binding_checker.cpp
@@ -10,11 +10,11 @@
 #include <exceptions.hpp>
 #include <hir/environment.hpp>
 #include <hir/expression_checker.hpp>
+#include <hir/free_type_variable_collector.hpp>
 #include <hir/let_binding_checker.hpp>
 #include <hir/nodes.hpp>
 #include <hir/type_converter.hpp>
 #include <hir/type_unifier.hpp>
-#include <hir/type_visitors.hpp>
 #include <hir/types.hpp>
 #include <source_location.hpp>
 #include <stdexcept>
@@ -55,7 +55,7 @@ LetBinding LetBindingChecker::operator()(const ast::LetBinding &let_binding) {
                                    let_binding.m_variable.m_name,
                                    unified_type};
 
-  FreeTypeVariableCollector collector{m_ctx.m_type_registry};
+  FreeTypeVariableCollector collector{m_ctx};
   collector.collect(new_identifier.m_type);
 
   // Store the new let binding

--- a/bust/hir/type_registry.cpp
+++ b/bust/hir/type_registry.cpp
@@ -15,8 +15,9 @@
 namespace bust::hir {
 //****************************************************************************
 
-std::string TypeRegistry::to_string(const TypeKind &type_kind) {
-  return std::visit(
+std::string TypeRegistry::to_string(const TypeKind &type_kind) const {
+  return "(" +
+         std::visit(
              [&](const auto &tk) -> std::string {
                using T = std::decay_t<decltype(tk)>;
                if constexpr (std::is_same_v<T, PrimitiveTypeValue>) {
@@ -25,16 +26,18 @@ std::string TypeRegistry::to_string(const TypeKind &type_kind) {
                } else if constexpr (std::is_same_v<T, TypeVariable>) {
                  return "?T<" + std::to_string(tk.m_id) + ">";
                } else if constexpr (std::is_same_v<T, FunctionType>) {
-                 std::string out = "(";
+                 std::string out{};
                  if (!tk.m_parameters.empty()) {
+                   out += "(";
                    for (size_t index = 0; index < tk.m_parameters.size() - 1;
                         ++index) {
                      out += to_string(get(tk.m_parameters[index]));
                      out += ", ";
                    }
                    out += to_string(get(tk.m_parameters.back()));
+                   out += ")";
                  }
-                 out += ") -> ";
+                 out += " -> ";
                  out += to_string(get(tk.m_return_type));
                  return out;
                } else if constexpr (std::is_same_v<T, NeverType>) {
@@ -42,10 +45,10 @@ std::string TypeRegistry::to_string(const TypeKind &type_kind) {
                }
              },
              type_kind) +
-         " : ID: " + std::to_string(m_mapping.at(type_kind).m_id);
+         " : ID: " + std::to_string(m_mapping.at(type_kind).m_id) + ")";
 }
 
-std::string TypeRegistry::to_string(TypeId type_id) {
+std::string TypeRegistry::to_string(TypeId type_id) const {
   return to_string(m_types.at(type_id.m_id));
 }
 

--- a/bust/hir/type_registry.hpp
+++ b/bust/hir/type_registry.hpp
@@ -48,8 +48,8 @@ struct TypeRegistry {
     return m_types[id.m_id];
   }
 
-  std::string to_string(const TypeKind &);
-  std::string to_string(TypeId);
+  std::string to_string(const TypeKind &) const;
+  std::string to_string(TypeId) const;
 
 private:
   std::vector<TypeKind> m_types{};

--- a/bust/hir/type_unifier.hpp
+++ b/bust/hir/type_unifier.hpp
@@ -8,10 +8,12 @@
 #pragma once
 //****************************************************************************
 
+#include "exceptions.hpp"
 #include "hir/type_registry.hpp"
 #include <hir/types.hpp>
 #include <hir/unifier_state.hpp>
 #include <hir/union_find.hpp>
+#include <optional>
 #include <ranges>
 #include <stdexcept>
 #include <types.hpp>
@@ -23,10 +25,18 @@ namespace bust::hir {
 //****************************************************************************
 
 struct TypeUnifier {
-  TypeVariable new_type_var() {
+  TypeVariable
+  new_type_var(std::optional<PrimitiveTypeClass> possible_constraint = {}) {
     auto new_id = m_union_find.add_node();
     auto new_type_var = TypeVariable{.m_id = new_id};
     m_type_registry.intern(new_type_var);
+
+    if (!possible_constraint.has_value()) {
+      return new_type_var;
+    }
+    // Check if the constraint conflicts, it shouldn't, but not bad to check
+    const auto &constraint = possible_constraint.value();
+    constrain(new_type_var, constraint);
     return new_type_var;
   }
 
@@ -296,6 +306,27 @@ struct TypeUnifier {
 
     // Not a concrete type yet
     return m_type_registry.intern(TypeVariable{root});
+  }
+
+  std::optional<PrimitiveTypeClass> find_type_class(const TypeVariable &type) {
+    auto root_id = find(type);
+
+    const auto &root = m_type_registry.get(root_id);
+
+    if (!std::holds_alternative<TypeVariable>(root)) {
+      throw core::InternalCompilerError(
+          "Should not call this method on a resolved type variable");
+    }
+
+    const auto &root_type_var = std::get<TypeVariable>(root);
+
+    auto iter = m_resolved_type_class.find(root_type_var.m_id);
+    if (iter == m_resolved_type_class.end()) {
+      return {};
+    }
+    // A constraint exists
+    auto constraint = iter->second;
+    return {constraint};
   }
 
   UnifierState extract_state() {

--- a/bust/hir/type_variable_updater.hpp
+++ b/bust/hir/type_variable_updater.hpp
@@ -1,14 +1,14 @@
 //**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
 //*
 //*
-//*  Purpose : Type visitors for bust HIR types (substitution, collection).
+//*  Purpose : Type variable substitution visitor for bust HIR types.
 //*
 //*
 //****************************************************************************
 #pragma once
 //****************************************************************************
 
-#include "hir/type_registry.hpp"
+#include <hir/type_registry.hpp>
 #include <hir/types.hpp>
 #include <unordered_map>
 #include <variant>
@@ -56,31 +56,6 @@ struct TypeVariableUpdater {
 
   TypeRegistry &m_type_registry;
   const std::unordered_map<TypeVariable, TypeVariable> &m_new_mapping;
-};
-
-struct FreeTypeVariableCollector {
-
-  void collect(const TypeKind &type) { std::visit(*this, type); }
-  void collect(const TypeId &type) { collect(m_type_registry.get(type)); }
-
-  void operator()(const PrimitiveTypeValue &) {}
-
-  void operator()(const TypeVariable &type) {
-    m_free_type_variables.emplace_back(type);
-  }
-
-  void operator()(const FunctionType &type) {
-    for (const auto &parameter : type.m_parameters) {
-      collect(m_type_registry.get(parameter));
-    }
-
-    collect(m_type_registry.get(type.m_return_type));
-  }
-
-  void operator()(const NeverType &) {}
-
-  TypeRegistry &m_type_registry;
-  std::vector<TypeVariable> m_free_type_variables{};
 };
 
 //****************************************************************************

--- a/bust/programs/bad_poly.bu
+++ b/bust/programs/bad_poly.bu
@@ -1,0 +1,4 @@
+fn main() -> i64 {
+   let f = |x| {x + x};
+   f(true)
+}

--- a/bust/programs/bad_poly_2.bu
+++ b/bust/programs/bad_poly_2.bu
@@ -1,0 +1,4 @@
+fn main() -> i64 {
+   let f = |x, y| {x + y};
+   f(1, true)
+}

--- a/bust/programs/bad_poly_3.bu
+++ b/bust/programs/bad_poly_3.bu
@@ -1,0 +1,7 @@
+fn main() -> i64 {
+   let my_i8 : i64 = 4;
+   let my_i64: i64 = 8;
+   let g = |h| { h };
+   let f = |x, y| {x + y};
+   g(f)(my_i8, my_i64)
+}

--- a/bust/src/bust.cpp
+++ b/bust/src/bust.cpp
@@ -44,15 +44,16 @@ void Bust::run() {
     std::cout << "=== AST ===\n" << ast::Dumper::dump(program) << "\n";
   }
 
-  auto typed =
-      run_pipeline(std::move(program), ValidateMain{}, TypeChecker{}, Zonker{});
+  auto typed = run_pipeline(std::move(program), ValidateMain{}, TypeChecker{});
 
   if (m_options.dump_hir) {
     std::cout << "=== HIR ===\n" << hir::Dumper::dump(typed) << "\n";
   }
 
+  auto zonked = run_pipeline(std::move(typed), Zonker{});
+
   if (m_options.llvm_ir) {
-    auto ir = CodeGen{}(typed);
+    auto ir = CodeGen{}(zonked);
     std::cout << "=== LLVM IR ===\n" << ir << "\n";
 
     // Write IR to a temp file and run via lli, then surface its exit code
@@ -79,7 +80,7 @@ void Bust::run() {
     return;
   }
 
-  auto result = Evaluator{}(typed);
+  auto result = Evaluator{}(zonked);
   std::cout << "Program returned: " << result << "\n";
 }
 

--- a/bust/test/src/type_unifier_test.cpp
+++ b/bust/test/src/type_unifier_test.cpp
@@ -10,8 +10,10 @@
 //*
 //****************************************************************************
 
+#include "hir/environment.hpp"
+#include <hir/free_type_variable_collector.hpp>
 #include <hir/type_unifier.hpp>
-#include <hir/type_visitors.hpp>
+#include <hir/type_variable_updater.hpp>
 #include <hir/types.hpp>
 
 #include <doctest/doctest.h>
@@ -249,7 +251,12 @@ TEST_SUITE("bust.free_type_variable_collector") {
     auto tv = unifier.new_type_var();
     hir::TypeKind type = tv;
 
-    hir::FreeTypeVariableCollector collector{type_registry};
+    auto env = hir::Environment{};
+    auto context = hir::Context{.m_env = env,
+                                .m_type_registry = type_registry,
+                                .m_return_type_stack{},
+                                .m_type_unifier{type_registry}};
+    hir::FreeTypeVariableCollector collector{context};
     std::visit(collector, type);
 
     CHECK(collector.m_free_type_variables.size() == 1);
@@ -260,7 +267,12 @@ TEST_SUITE("bust.free_type_variable_collector") {
     hir::TypeKind type = hir::PrimitiveTypeValue{PrimitiveType::I64};
 
     hir::TypeRegistry type_registry{};
-    hir::FreeTypeVariableCollector collector{type_registry};
+    auto env = hir::Environment{};
+    auto context = hir::Context{.m_env = env,
+                                .m_type_registry = type_registry,
+                                .m_return_type_stack{},
+                                .m_type_unifier{type_registry}};
+    hir::FreeTypeVariableCollector collector{context};
     std::visit(collector, type);
 
     CHECK(collector.m_free_type_variables.empty());
@@ -270,7 +282,12 @@ TEST_SUITE("bust.free_type_variable_collector") {
     hir::TypeKind type = hir::NeverType{};
 
     hir::TypeRegistry type_registry{};
-    hir::FreeTypeVariableCollector collector{type_registry};
+    auto env = hir::Environment{};
+    auto context = hir::Context{.m_env = env,
+                                .m_type_registry = type_registry,
+                                .m_return_type_stack{},
+                                .m_type_unifier{type_registry}};
+    hir::FreeTypeVariableCollector collector{context};
     std::visit(collector, type);
 
     CHECK(collector.m_free_type_variables.empty());
@@ -288,7 +305,12 @@ TEST_SUITE("bust.free_type_variable_collector") {
     hir::TypeKind fn_type =
         hir::FunctionType{std::move(params), type_registry.intern(t1)};
 
-    hir::FreeTypeVariableCollector collector{type_registry};
+    auto env = hir::Environment{};
+    auto context = hir::Context{.m_env = env,
+                                .m_type_registry = type_registry,
+                                .m_return_type_stack{},
+                                .m_type_unifier{type_registry}};
+    hir::FreeTypeVariableCollector collector{context};
     std::visit(collector, fn_type);
 
     CHECK(collector.m_free_type_variables.size() == 2);
@@ -305,7 +327,12 @@ TEST_SUITE("bust.free_type_variable_collector") {
     hir::TypeKind fn_type =
         hir::FunctionType{std::move(params), type_registry.intern(t1)};
 
-    hir::FreeTypeVariableCollector collector{type_registry};
+    auto env = hir::Environment{};
+    auto context = hir::Context{.m_env = env,
+                                .m_type_registry = type_registry,
+                                .m_return_type_stack{},
+                                .m_type_unifier{type_registry}};
+    hir::FreeTypeVariableCollector collector{context};
     std::visit(collector, fn_type);
 
     CHECK(collector.m_free_type_variables.size() == 1);

--- a/monomorphization.md
+++ b/monomorphization.md
@@ -1,0 +1,86 @@
+# Monomorphization
+
+## Problem
+
+The type checker supports let-polymorphism: unconstrained type variables in
+let-bound lambdas are generalized and instantiated with fresh variables at each
+use site. This means polymorphic definitions (e.g., the identity function) carry
+type variables that are never resolved to concrete types.
+
+The zonker assumes all type variables resolve to concrete types. Polymorphic
+definitions violate this, causing an ICE in the zonk pass.
+
+```rust
+fn main() -> i64 {
+  let g = |h| { h };       // g: forall T. T -> T
+  let f = |x, y| { x + y };
+  g(f)(4, 8)               // g instantiated at (i64, i64) -> i64
+}
+```
+
+`g`'s definition-site type variable is never resolved — only its fresh
+instantiations are.
+
+## Approach
+
+For each polymorphic definition, stamp out a specialized copy for every concrete
+type it is instantiated at. After monomorphization, no type variables remain.
+
+## Prerequisites
+
+- Canonicalize unified type variables before generalization (zonk at the
+  generalization point in the let binding checker). Without this, unified
+  variables like `?0` and `?1` from `x + y` are generalized independently.
+- Propagate type class constraints through `create_fresh_type_vars` (done).
+- Filter resolved type variables from generalization (done).
+
+## Work Items
+
+### 1. Instantiation tracking
+
+During type checking, record each instantiation of a polymorphic type scheme.
+When `create_fresh_type_vars` fires, store the mapping from the original free
+variables to the concrete types they eventually resolve to. This needs to be
+collected after unification completes for the enclosing scope — the fresh
+variables may not be resolved at the point of instantiation.
+
+### 2. HIR cloning with type substitution
+
+Deep-copy a LambdaExpr (and its full expression tree), replacing type variables
+with concrete types. Requires clone methods across all HIR node types since they
+use `unique_ptr`. Each cloned node's TypeId must point to a valid entry in the
+type registry.
+
+### 3. Call site rewriting
+
+Replace references to polymorphic definitions with references to their
+specialized copies. A polymorphic function used at three different types
+produces three specialized definitions and three distinct call site rewrites.
+
+### 4. Monomorphization pass
+
+New pass between type checking and zonking. Walks all top-level items and
+let bindings, finds polymorphic definitions, and for each recorded
+instantiation:
+- Clones the definition with concrete type substitutions
+- Rewrites call sites to reference the specialized copy
+- Produces a program with no remaining type variables
+
+The zonk pass then becomes a validation-only step (or is removed).
+
+### 5. Name mangling
+
+Each specialized copy needs a unique name for codegen. Something like
+`g_fn_i64_i64_to_i64` or a simpler numeric suffix scheme.
+
+## Edge Cases
+
+- **Nested polymorphism**: `g(f)` where both are polymorphic — `g` is
+  specialized first, which may reveal the concrete type for `f`.
+- **Multiple instantiations**: Same function used at different types in
+  different let bindings or call sites.
+- **Unused polymorphic definitions**: No instantiation recorded — can be
+  dropped or flagged as dead code.
+- **Recursive self-calls at the same type**: Safe (single specialization).
+  Recursive calls at different types would not terminate — not currently
+  possible in bust but worth guarding against.


### PR DESCRIPTION
Fix up the hir dumper
Correctly propagate constraints when substituting new type variables for polymorphic lambdas