### PR TITLE
Type Checker Refactorin

### DIFF
--- a/archive/type_checker_refactor.md
+++ b/archive/type_checker_refactor.md
@@ -45,12 +45,14 @@ is Never. The carrier-slot framing is what lets return / break / panic /
 loop {} share one type-level story while differing only in what they
 ferry away.
 
-**Type-level**: Never is the bottom of a tiny subtype lattice. The
-operations the system uses are `unify` (HM equation-solving — Never as
-no-op is correct), `join` (least upper bound — needed for if/match/loop
-result types), and eventually `is_subtype` (Never coerces to anything).
-Carrier slots are themselves joined across all contributors (every
-`return e` in a function, every `break e` in a loop).
+**Type-level**: bust uses two operations on types — `unify` (HM
+equation-solving; Never short-circuits as a no-op) and `join` (least
+upper bound, needed for if/match/loop result types; Never is absorbed).
+Each operation hand-codes its Never rule today (three sites in
+`hir/type_unifier.hpp`); that's adequate for the current algebra and
+not worth a bottom-type encoding. Carrier slots are themselves joined
+across all contributors (every `return e` in a function, every
+`break e` in a loop).
 
 **Inference boundary**: when inference finishes, residual unconstrained
 type variables that flowed from a Never expression default to Unit.
@@ -61,18 +63,28 @@ Codegen treats it as no-op-on-store / unreachable-on-load. The mangler
 only needs a canonical name for Never if Never appears in a mangled
 signature — not necessary until `!` is user-facing as a return type.
 
-## Tasks
+## What landed
 
-### Tier 1 — small, immediate, high-leverage
+- **TypeFolder consolidation.** Three near-identical visitors (`TypeVariableSubstituter`, `TypeVariableCollapser`, `FreeTypeVariableCollector`) collapsed into one function+functor pair (`fold` / `walk`) at `hir/type_folder.hpp`. Callers reduced to small lambdas at `hir/type_variable_substituter.hpp`, `hir/type_variable_collapser.hpp`, and `hir/free_type_variable_collector.hpp`.
+- **Semantics framing.** The carrier-slot model (above) ties return / break / panic / loop {} into one type-level story.
+- **Implicit invariant check.** The `InternalCompilerError` throws at `mono/name_mangler.hpp:75-77` and `zir/context.hpp:62-63` document the "no `TypeVariable` past TypeChecker" invariant. Tests exercise generalization paths heavily without hitting them.
+- **Reachability cleanup.** Per-arm sanity asserts in `IfExpr` codegen were dropped; codegen now relies on `current_block_terminated`.
 
-- [ ] Audit whether anything other than the let-binding generalizer (`hir/statement_checker.cpp:66`, where `collapse_types` runs to surface free tvars for the `TypeScheme`) can leak a `TypeVariable` past TypeChecker. If not, the existing `InternalCompilerError` throws in `mono/name_mangler.hpp` and `zir/context.hpp` document the invariant correctly and need no further work
+## Deferred — gated on concrete motivation
 
-### Tier 2 — medium, good payoff
+- **Generalize the never-type fallback.** The local form at `hir/statement_checker.cpp:56-61` covers every case bust hits today. Promote to an end-of-TypeChecker pass when a pattern leaks past it (likely needs generic containers or user-visible `!` first). Implementation would build on `walk` / `fold`.
+- **Reachability as `Block::is_divergent` field.** Codegen would read precomputed instead of tracking `current_block_terminated`. Open only if codegen state-tracking starts hurting.
 
-- [ ] Generalize the never-type fallback. A local version landed in `hir/statement_checker.cpp:56-61` for let-bindings; promote to a single end-of-TypeChecker pass over residual tvars that flowed from Never. Build it on top of `walk`/`fold` in `hir/type_folder.hpp`
-- [ ] Move reachability into HIR as explicit field on `Block` (`is_divergent: bool`); codegen reads instead of recomputing via `current_block_terminated`. Would also let codegen drop the per-arm sanity-check asserts in `IfExpr`
+## Direction — trait/class system, not subtyping
 
-### Tier 3 — larger, deferred
+Subtyping is not bust's path. Its only payoff here is the Never special-case cleanup — three small sites in `hir/type_unifier.hpp`. The cost is converting inference from equation-solving to inequation-solving, a fundamental algorithmic shift Rust spent years debugging.
 
-- [ ] Split `TypeUnifier` and `TypeClassResolver` (constraint side) into separate composable pieces
-- [ ] Introduce subtyping/coercion as a first-class concept; add `is_subtype(τ_from, τ_to)`; let Never participate as real bottom; usable by literal coercion (i64-literal to i32 in context), auto-deref, etc.
+The next type-system addition is a **trait/class system**, integrated *additively* with HM: trait obligations become a separate constraint kind resolved by a separate solver, leaving unification untouched. Bust already has the seed (`PrimitiveTypeClass`).
+
+Motivating cases — none exist yet, but on the natural roadmap:
+
+- Generic numeric code: `fn sum<T: Add>(xs: Vec<T>) -> T`
+- User-defined `Eq` / `Ord` / `Display`
+- Iteration protocol
+
+When trait machinery grows enough to feel cramped sharing space with the unifier, that's the signal to split `TypeUnifier` and `TypeClassResolver` into separate composable pieces.

--- a/bust/hir/context.hpp
+++ b/bust/hir/context.hpp
@@ -48,10 +48,6 @@ struct Context {
       m_instantiation_records[id].push_back(InstantiationRecord{new_mapping});
     }
 
-    // return TypeVariableSubstituter{.m_type_arena = m_type_arena,
-    //                                .m_type_unifier = m_type_unifier,
-    //                                .m_new_mapping = new_mapping}
-    //     .substitute(type_scheme.m_type);
     return substitute_types(m_type_arena, m_type_unifier, type_scheme.m_type,
                             new_mapping);
   }

--- a/bust/hir/context.hpp
+++ b/bust/hir/context.hpp
@@ -48,10 +48,12 @@ struct Context {
       m_instantiation_records[id].push_back(InstantiationRecord{new_mapping});
     }
 
-    return TypeVariableSubstituter{.m_type_arena = m_type_arena,
-                                   .m_type_unifier = m_type_unifier,
-                                   .m_new_mapping = new_mapping}
-        .substitute(type_scheme.m_type);
+    // return TypeVariableSubstituter{.m_type_arena = m_type_arena,
+    //                                .m_type_unifier = m_type_unifier,
+    //                                .m_new_mapping = new_mapping}
+    //     .substitute(type_scheme.m_type);
+    return substitute_types(m_type_arena, m_type_unifier, type_scheme.m_type,
+                            new_mapping);
   }
 
   [[nodiscard]] const FunctionType &as_function(TypeId type_id) const {

--- a/bust/hir/free_type_variable_collector.hpp
+++ b/bust/hir/free_type_variable_collector.hpp
@@ -11,50 +11,33 @@
 #include <hir/context.hpp>
 #include <hir/types.hpp>
 
+#include "hir/type_folder.hpp"
+
 //****************************************************************************
 namespace bust::hir {
 //****************************************************************************
 
-struct FreeTypeVariableCollector {
+inline std::vector<TypeId> collect_free_variables(hir::Context &ctx,
+                                                  TypeId type_id) {
+  std::vector<TypeId> free_type_variables;
 
-  explicit FreeTypeVariableCollector(Context &ctx) : m_ctx(ctx) {}
-
-  void collect(const TypeKind &type) { std::visit(*this, type); }
-  void collect(const TypeId &type) { collect(m_ctx.m_type_arena.get(type)); }
-
-  void operator()(const PrimitiveTypeValue & /*unused*/) {}
-
-  void operator()(const TypeVariable &type) {
-    // Let's try to resolve the types first
-    auto resolved_type_id = m_ctx.m_type_unifier.find(type);
-    if (!m_ctx.is_type_variable(resolved_type_id)) {
+  auto collect_from_type_variable = [&](const TypeVariable &type_variable) {
+    auto resolved_type_id = ctx.m_type_unifier.find(type_variable);
+    if (!ctx.is_type_variable(resolved_type_id)) {
       return;
     }
-    m_free_type_variables.emplace_back(resolved_type_id);
-  }
+    free_type_variables.emplace_back(resolved_type_id);
+  };
 
-  void operator()(const FunctionType &type) {
-    for (const auto &parameter : type.m_parameters) {
-      collect(parameter);
-    }
+  walk(ctx.m_type_arena, type_id, collect_from_type_variable);
 
-    collect(type.m_return_type);
-  }
+  return free_type_variables;
+}
 
-  void operator()(const TupleType &type) {
-    for (const auto &field : type.m_fields) {
-      collect(field);
-    }
-  }
-
-  void operator()(const NeverType & /*unused*/) {}
-
-  std::vector<TypeId> &free_type_variables() { return m_free_type_variables; }
-
-private:
-  hir::Context &m_ctx;
-  std::vector<TypeId> m_free_type_variables;
-};
+inline std::vector<TypeId> collect_free_variables(hir::Context &ctx,
+                                                  const TypeKind &type) {
+  return collect_free_variables(ctx, ctx.m_type_arena.intern(type));
+}
 
 //****************************************************************************
 } // namespace bust::hir

--- a/bust/hir/free_type_variable_collector.hpp
+++ b/bust/hir/free_type_variable_collector.hpp
@@ -9,9 +9,8 @@
 //****************************************************************************
 
 #include <hir/context.hpp>
+#include <hir/type_folder.hpp>
 #include <hir/types.hpp>
-
-#include "hir/type_folder.hpp"
 
 //****************************************************************************
 namespace bust::hir {

--- a/bust/hir/statement_checker.cpp
+++ b/bust/hir/statement_checker.cpp
@@ -73,17 +73,15 @@ Statement StatementChecker::operator()(const ast::LetBinding &let_binding) {
       collapsed_type,
   };
 
-  auto collector = FreeTypeVariableCollector(m_ctx);
-  collector.collect(new_identifier.m_type);
+  auto free_variables = collect_free_variables(m_ctx, new_identifier.m_type);
 
   // Store the new let binding
-  m_ctx.m_env.define(
-      new_identifier.m_name, binding_id,
-      TypeScheme{
-          .m_type = new_identifier.m_type,
-          .m_free_type_variables = std::move(collector.free_type_variables()),
-      },
-      let_binding.m_is_mutable);
+  m_ctx.m_env.define(new_identifier.m_name, binding_id,
+                     TypeScheme{
+                         .m_type = new_identifier.m_type,
+                         .m_free_type_variables = free_variables,
+                     },
+                     let_binding.m_is_mutable);
 
   return LetBinding{
       {let_binding.m_location},

--- a/bust/hir/statement_checker.cpp
+++ b/bust/hir/statement_checker.cpp
@@ -62,7 +62,8 @@ Statement StatementChecker::operator()(const ast::LetBinding &let_binding) {
 
   auto unified_type = m_ctx.m_type_unifier.find(annotated_type);
 
-  auto collapsed_type = TypeVariableCollapser{m_ctx}.collapse(unified_type);
+  auto collapsed_type =
+      collapse_types(m_ctx.m_type_arena, m_ctx.m_type_unifier, unified_type);
 
   auto binding_id = m_ctx.next_let_binding_id();
 

--- a/bust/hir/type_folder.hpp
+++ b/bust/hir/type_folder.hpp
@@ -8,6 +8,7 @@
 #pragma once
 //****************************************************************************
 
+#include <exceptions.hpp>
 #include <hir/type_arena.hpp>
 #include <hir/types.hpp>
 
@@ -19,7 +20,7 @@ namespace bust::hir {
 
 template <typename TypeVariableFunctor>
 TypeId fold(TypeArena &type_arena, TypeId type_id,
-            TypeVariableFunctor &&Functor) {
+            TypeVariableFunctor &&functor) {
   auto type_kind = type_arena.get(type_id);
   return std::visit(
       [&](auto &&tk) -> TypeId {
@@ -27,22 +28,22 @@ TypeId fold(TypeArena &type_arena, TypeId type_id,
         if constexpr (std::is_same_v<T, PrimitiveTypeValue>) {
           return type_arena.intern(tk);
         } else if constexpr (std::is_same_v<T, TypeVariable>) {
-          return Functor(tk);
+          return functor(tk);
         } else if constexpr (std::is_same_v<T, FunctionType>) {
           std::vector<TypeId> parameters;
           parameters.reserve(tk.m_parameters.size());
           for (const auto &parameter : tk.m_parameters) {
-            parameters.emplace_back(fold(type_arena, parameter, Functor));
+            parameters.emplace_back(fold(type_arena, parameter, functor));
           }
           return type_arena.intern(FunctionType{
               .m_parameters = std::move(parameters),
-              .m_return_type = fold(type_arena, tk.m_return_type, Functor),
+              .m_return_type = fold(type_arena, tk.m_return_type, functor),
           });
         } else if constexpr (std::is_same_v<T, TupleType>) {
           std::vector<TypeId> fields;
           fields.reserve(tk.m_fields.size());
           for (const auto &field : tk.m_fields) {
-            fields.emplace_back(fold(type_arena, field, Functor));
+            fields.emplace_back(fold(type_arena, field, functor));
           }
           return type_arena.intern(TupleType{
               .m_fields = std::move(fields),
@@ -56,22 +57,27 @@ TypeId fold(TypeArena &type_arena, TypeId type_id,
 
 template <typename TypeVariableFunctor>
 void walk(TypeArena &type_arena, TypeId type_id,
-          TypeVariableFunctor &&Functor) {
+          TypeVariableFunctor &&functor) {
   auto type_kind = type_arena.get(type_id);
   std::visit(
       [&](auto &&tk) {
         using T = std::decay_t<decltype(tk)>;
         if constexpr (std::is_same_v<T, TypeVariable>) {
-          Functor(tk);
+          functor(tk);
         } else if constexpr (std::is_same_v<T, FunctionType>) {
           for (const auto &parameter : tk.m_parameters) {
-            walk(type_arena, parameter, Functor);
+            walk(type_arena, parameter, functor);
           }
-          walk(type_arena, tk.m_return_type, Functor);
+          walk(type_arena, tk.m_return_type, functor);
         } else if constexpr (std::is_same_v<T, TupleType>) {
           for (const auto &field : tk.m_fields) {
-            walk(type_arena, field, Functor);
+            walk(type_arena, field, functor);
           }
+        } else if constexpr (std::is_same_v<T, PrimitiveTypeValue> ||
+                             std::is_same_v<T, NeverType>) {
+          // Do nothing
+        } else {
+          static_assert(false, "Unhandled type!");
         }
       },
       type_kind);

--- a/bust/hir/type_folder.hpp
+++ b/bust/hir/type_folder.hpp
@@ -1,0 +1,82 @@
+//**** Copyright © 2023-2026 Sean Carroll. All rights reserved.
+//*
+//*
+//*  Purpose : Generic fold over bust HIR types.
+//*
+//*
+//****************************************************************************
+#pragma once
+//****************************************************************************
+
+#include <hir/type_arena.hpp>
+#include <hir/types.hpp>
+
+#include <variant>
+
+//****************************************************************************
+namespace bust::hir {
+//****************************************************************************
+
+template <typename TypeVariableFunctor>
+TypeId fold(TypeArena &type_arena, TypeId type_id,
+            TypeVariableFunctor &&Functor) {
+  auto type_kind = type_arena.get(type_id);
+  return std::visit(
+      [&](auto &&tk) -> TypeId {
+        using T = std::decay_t<decltype(tk)>;
+        if constexpr (std::is_same_v<T, PrimitiveTypeValue>) {
+          return type_arena.intern(tk);
+        } else if constexpr (std::is_same_v<T, TypeVariable>) {
+          return Functor(tk);
+        } else if constexpr (std::is_same_v<T, FunctionType>) {
+          std::vector<TypeId> parameters;
+          parameters.reserve(tk.m_parameters.size());
+          for (const auto &parameter : tk.m_parameters) {
+            parameters.emplace_back(fold(type_arena, parameter, Functor));
+          }
+          return type_arena.intern(FunctionType{
+              .m_parameters = std::move(parameters),
+              .m_return_type = fold(type_arena, tk.m_return_type, Functor),
+          });
+        } else if constexpr (std::is_same_v<T, TupleType>) {
+          std::vector<TypeId> fields;
+          fields.reserve(tk.m_fields.size());
+          for (const auto &field : tk.m_fields) {
+            fields.emplace_back(fold(type_arena, field, Functor));
+          }
+          return type_arena.intern(TupleType{
+              .m_fields = std::move(fields),
+          });
+        } else if constexpr (std::is_same_v<T, NeverType>) {
+          return type_arena.m_never;
+        }
+      },
+      type_kind);
+}
+
+template <typename TypeVariableFunctor>
+void walk(TypeArena &type_arena, TypeId type_id,
+          TypeVariableFunctor &&Functor) {
+  auto type_kind = type_arena.get(type_id);
+  std::visit(
+      [&](auto &&tk) {
+        using T = std::decay_t<decltype(tk)>;
+        if constexpr (std::is_same_v<T, TypeVariable>) {
+          Functor(tk);
+        } else if constexpr (std::is_same_v<T, FunctionType>) {
+          for (const auto &parameter : tk.m_parameters) {
+            walk(type_arena, parameter, Functor);
+          }
+          walk(type_arena, tk.m_return_type, Functor);
+        } else if constexpr (std::is_same_v<T, TupleType>) {
+          for (const auto &field : tk.m_fields) {
+            walk(type_arena, field, Functor);
+          }
+        }
+      },
+      type_kind);
+}
+
+//****************************************************************************
+} // namespace bust::hir
+//****************************************************************************

--- a/bust/hir/type_variable_collapser.hpp
+++ b/bust/hir/type_variable_collapser.hpp
@@ -9,60 +9,22 @@
 //****************************************************************************
 
 #include <hir/context.hpp>
+#include <hir/type_folder.hpp>
 #include <hir/types.hpp>
 
 //****************************************************************************
 namespace bust::hir {
 //****************************************************************************
 
-struct TypeVariableCollapser {
-
-  TypeId collapse(const TypeKind &type) { return std::visit(*this, type); }
-  TypeId collapse(const TypeId &type) {
-    return collapse(m_ctx.m_type_arena.get(type));
-  }
-
-  TypeId operator()(const PrimitiveTypeValue &type) {
-    return m_ctx.m_type_arena.intern(type);
-  }
-
-  TypeId operator()(const TypeVariable &type) {
-    auto resolved_type_id = m_ctx.m_type_unifier.find(type);
+inline TypeId collapse_types(TypeArena &type_arena, TypeUnifier &type_unifier,
+                             TypeId type_id) {
+  auto type_variable_collapser =
+      [&](const TypeVariable &type_variable) -> TypeId {
+    auto resolved_type_id = type_unifier.find(type_variable);
     return resolved_type_id;
-  }
-
-  TypeId operator()(const FunctionType &type) {
-    std::vector<TypeId> parameters;
-    parameters.reserve(type.m_parameters.size());
-    for (const auto &parameter : type.m_parameters) {
-      parameters.push_back(collapse(parameter));
-    }
-
-    auto function_type =
-        FunctionType{.m_parameters = std::move(parameters),
-                     .m_return_type = collapse(type.m_return_type)};
-    return m_ctx.m_type_arena.intern(function_type);
-  }
-
-  TypeId operator()(const TupleType &type) {
-    std::vector<TypeId> fields;
-    fields.reserve(type.m_fields.size());
-    for (const auto &field : type.m_fields) {
-      fields.push_back(collapse(field));
-    }
-
-    auto tuple_type = TupleType{
-        .m_fields = std::move(fields),
-    };
-    return m_ctx.m_type_arena.intern(tuple_type);
-  }
-
-  TypeId operator()(const NeverType & /*unused*/) {
-    return m_ctx.m_type_arena.m_never;
-  }
-
-  hir::Context &m_ctx;
-};
+  };
+  return fold(type_arena, type_id, type_variable_collapser);
+}
 
 //****************************************************************************
 } // namespace bust::hir

--- a/bust/hir/type_variable_substituter.hpp
+++ b/bust/hir/type_variable_substituter.hpp
@@ -9,82 +9,42 @@
 //****************************************************************************
 
 #include <hir/type_arena.hpp>
+#include <hir/type_folder.hpp>
 #include <hir/type_unifier.hpp>
 #include <hir/types.hpp>
 
 #include <unordered_map>
 #include <variant>
-#include <vector>
 
 //****************************************************************************
 namespace bust::hir {
 //****************************************************************************
 
-struct TypeVariableSubstituter {
-  TypeId substitute(TypeId type_id) {
-    // Explicitly keep as copy rather than const ref so ref doesn't go stale as
-    // we intern types during traversal of recursive types
-    TypeKind type = m_type_arena.get(type_id);
-    return std::visit(*this, type);
-  }
-
-  TypeId operator()(const PrimitiveTypeValue &type) {
-    return m_type_arena.intern(type);
-  }
-
-  TypeId operator()(const TypeVariable &type) {
-    auto type_id = m_type_arena.intern(type);
-    auto iter = m_new_mapping.find(type_id);
-
-    if (iter == m_new_mapping.end()) {
-      auto resolved_type_id = m_type_unifier.find(type);
-      auto resolved_iter = m_new_mapping.find(resolved_type_id);
-      if (resolved_iter != m_new_mapping.end()) {
+inline TypeId
+substitute_types(TypeArena &type_arena, TypeUnifier &type_unifier,
+                 TypeId type_id,
+                 const std::unordered_map<TypeId, TypeId> &new_mapping) {
+  auto type_variable_substituter =
+      [&](const TypeVariable &type_variable) -> TypeId {
+    auto type_id = type_arena.intern(type_variable);
+    auto iter = new_mapping.find(type_id);
+    if (iter == new_mapping.end()) {
+      auto resolved_type_id = type_unifier.find(type_variable);
+      auto resolved_iter = new_mapping.find(resolved_type_id);
+      if (resolved_iter != new_mapping.end()) {
         return resolved_iter->second;
       }
-      if (m_type_arena.is_type_variable(resolved_type_id)) {
+      if (type_arena.is_type_variable(resolved_type_id)) {
         return resolved_type_id;
       }
       // Otherwise, recurse on it?
-      return substitute(resolved_type_id);
+      return substitute_types(type_arena, type_unifier, resolved_type_id,
+                              new_mapping);
     }
-
     return iter->second;
-  }
-
-  TypeId operator()(const FunctionType &type) {
-    std::vector<TypeId> parameters;
-    parameters.reserve(type.m_parameters.size());
-    for (const auto &parameter : type.m_parameters) {
-      parameters.emplace_back(substitute(parameter));
-    }
-
-    return m_type_arena.intern(FunctionType{
-        .m_parameters = std::move(parameters),
-        .m_return_type = substitute(type.m_return_type),
-    });
-  }
-
-  TypeId operator()(const TupleType &type) {
-    std::vector<TypeId> fields;
-    fields.reserve(type.m_fields.size());
-    for (const auto &field : type.m_fields) {
-      fields.emplace_back(substitute(field));
-    }
-
-    return m_type_arena.intern(TupleType{
-        .m_fields = std::move(fields),
-    });
-  }
-
-  TypeId operator()(const NeverType & /*unused*/) {
-    return m_type_arena.m_never;
-  }
-
-  TypeArena &m_type_arena;
-  TypeUnifier &m_type_unifier;
-  const std::unordered_map<TypeId, TypeId> &m_new_mapping;
-};
+  };
+  return fold(type_arena, type_id, type_variable_substituter);
+}
 
 //****************************************************************************
 } // namespace bust::hir

--- a/bust/mono/context.hpp
+++ b/bust/mono/context.hpp
@@ -42,11 +42,15 @@ struct Context {
 
 struct SubstitutionContext {
   hir::TypeId rewrite_type(hir::TypeId type_id) {
-    return hir::TypeVariableSubstituter{.m_type_arena = m_parent.type_arena(),
-                                        .m_type_unifier =
-                                            m_parent.m_type_unifier,
-                                        .m_new_mapping = m_substitution_mapping}
-        .substitute(type_id);
+    return hir::substitute_types(type_arena(), m_parent.m_type_unifier, type_id,
+                                 m_substitution_mapping);
+    // return hir::TypeVariableSubstituter{.m_type_arena =
+    // m_parent.type_arena(),
+    //                                     .m_type_unifier =
+    //                                         m_parent.m_type_unifier,
+    //                                     .m_new_mapping =
+    //                                     m_substitution_mapping}
+    //     .substitute(type_id);
   }
 
   hir::TypeArena &type_arena() { return m_parent.type_arena(); }

--- a/bust/mono/context.hpp
+++ b/bust/mono/context.hpp
@@ -44,13 +44,6 @@ struct SubstitutionContext {
   hir::TypeId rewrite_type(hir::TypeId type_id) {
     return hir::substitute_types(type_arena(), m_parent.m_type_unifier, type_id,
                                  m_substitution_mapping);
-    // return hir::TypeVariableSubstituter{.m_type_arena =
-    // m_parent.type_arena(),
-    //                                     .m_type_unifier =
-    //                                         m_parent.m_type_unifier,
-    //                                     .m_new_mapping =
-    //                                     m_substitution_mapping}
-    //     .substitute(type_id);
   }
 
   hir::TypeArena &type_arena() { return m_parent.type_arena(); }

--- a/bust/mono/let_binding_monomorpher.cpp
+++ b/bust/mono/let_binding_monomorpher.cpp
@@ -51,14 +51,8 @@ std::vector<hir::LetBinding> LetBindingMonomorpher::monomorph(
     // Record the specialization in the table
 
     hir::TypeSubstitution combined = outer_substitution;
-    // auto substituter =
-    //     hir::TypeVariableSubstituter{.m_type_arena = m_ctx.type_arena(),
-    //                                  .m_type_unifier = m_ctx.m_type_unifier,
-    //                                  .m_new_mapping = outer_substitution};
     for (const auto &[original_type_id, substituted_type_id] :
          record.m_substitution) {
-      // combined[original_type_id] =
-      // substituter.substitute(substituted_type_id);
       combined[original_type_id] =
           hir::substitute_types(m_ctx.type_arena(), m_ctx.m_type_unifier,
                                 substituted_type_id, outer_substitution);
@@ -73,10 +67,6 @@ std::vector<hir::LetBinding> LetBindingMonomorpher::monomorph(
     auto new_type =
         hir::substitute_types(m_ctx.type_arena(), m_ctx.m_type_unifier,
                               let_binding.m_expression.m_type, combined);
-    // hir::TypeVariableSubstituter{.m_type_arena = m_ctx.type_arena(),
-    //                              .m_type_unifier = m_ctx.m_type_unifier,
-    //                              .m_new_mapping = combined}
-    //     .substitute(let_binding.m_expression.m_type);
 
     auto new_id = m_ctx.next_let_binding_id();
     auto new_name = Mangler(m_ctx.type_arena())

--- a/bust/mono/let_binding_monomorpher.cpp
+++ b/bust/mono/let_binding_monomorpher.cpp
@@ -51,13 +51,17 @@ std::vector<hir::LetBinding> LetBindingMonomorpher::monomorph(
     // Record the specialization in the table
 
     hir::TypeSubstitution combined = outer_substitution;
-    auto substituter =
-        hir::TypeVariableSubstituter{.m_type_arena = m_ctx.type_arena(),
-                                     .m_type_unifier = m_ctx.m_type_unifier,
-                                     .m_new_mapping = outer_substitution};
+    // auto substituter =
+    //     hir::TypeVariableSubstituter{.m_type_arena = m_ctx.type_arena(),
+    //                                  .m_type_unifier = m_ctx.m_type_unifier,
+    //                                  .m_new_mapping = outer_substitution};
     for (const auto &[original_type_id, substituted_type_id] :
          record.m_substitution) {
-      combined[original_type_id] = substituter.substitute(substituted_type_id);
+      // combined[original_type_id] =
+      // substituter.substitute(substituted_type_id);
+      combined[original_type_id] =
+          hir::substitute_types(m_ctx.type_arena(), m_ctx.m_type_unifier,
+                                substituted_type_id, outer_substitution);
     }
 
     auto context = SubstitutionContext{.m_parent = m_ctx,
@@ -67,10 +71,12 @@ std::vector<hir::LetBinding> LetBindingMonomorpher::monomorph(
     combined = context.m_substitution_mapping;
 
     auto new_type =
-        hir::TypeVariableSubstituter{.m_type_arena = m_ctx.type_arena(),
-                                     .m_type_unifier = m_ctx.m_type_unifier,
-                                     .m_new_mapping = combined}
-            .substitute(let_binding.m_expression.m_type);
+        hir::substitute_types(m_ctx.type_arena(), m_ctx.m_type_unifier,
+                              let_binding.m_expression.m_type, combined);
+    // hir::TypeVariableSubstituter{.m_type_arena = m_ctx.type_arena(),
+    //                              .m_type_unifier = m_ctx.m_type_unifier,
+    //                              .m_new_mapping = combined}
+    //     .substitute(let_binding.m_expression.m_type);
 
     auto new_id = m_ctx.next_let_binding_id();
     auto new_name = Mangler(m_ctx.type_arena())

--- a/bust/test/src/type_unifier_test.cpp
+++ b/bust/test/src/type_unifier_test.cpp
@@ -250,30 +250,27 @@ TEST_SUITE("bust.free_type_variable_collector") {
     auto tv = context.m_type_unifier.new_type_var();
     hir::TypeKind type = context.m_type_arena.as_type_variable(tv);
 
-    hir::FreeTypeVariableCollector collector{context};
-    std::visit(collector, type);
+    auto free_type_variables = collect_free_variables(context, type);
 
-    CHECK(collector.free_type_variables().size() == 1);
-    CHECK(collector.free_type_variables()[0].m_id == tv.m_id);
+    CHECK(free_type_variables.size() == 1);
+    CHECK(free_type_variables[0].m_id == tv.m_id);
   }
 
   TEST_CASE("collects nothing from concrete primitive") {
     hir::TypeKind type = hir::PrimitiveTypeValue{PrimitiveType::I64};
 
     auto context = hir::Context{};
-    hir::FreeTypeVariableCollector collector{context};
-    std::visit(collector, type);
+    auto free_type_variables = collect_free_variables(context, type);
 
-    CHECK(collector.free_type_variables().empty());
+    CHECK(free_type_variables.empty());
   }
 
   TEST_CASE("collects nothing from NeverType") {
     hir::TypeKind type = hir::NeverType{};
     auto context = hir::Context{};
-    hir::FreeTypeVariableCollector collector{context};
-    std::visit(collector, type);
+    auto free_type_variables = collect_free_variables(context, type);
 
-    CHECK(collector.free_type_variables().empty());
+    CHECK(free_type_variables.empty());
   }
 
   TEST_CASE("collects TVs from inside FunctionType") {
@@ -286,10 +283,9 @@ TEST_SUITE("bust.free_type_variable_collector") {
     params.emplace_back(t0);
     hir::TypeKind fn_type = hir::FunctionType{std::move(params), t1};
 
-    hir::FreeTypeVariableCollector collector{context};
-    std::visit(collector, fn_type);
+    auto free_type_variables = collect_free_variables(context, fn_type);
 
-    CHECK(collector.free_type_variables().size() == 2);
+    CHECK(free_type_variables.size() == 2);
   }
 
   TEST_CASE("collects only TVs not concrete parts of fn type") {
@@ -301,11 +297,10 @@ TEST_SUITE("bust.free_type_variable_collector") {
     params.emplace_back(context.m_type_arena.m_i64);
     hir::TypeKind fn_type = hir::FunctionType{std::move(params), t1};
 
-    hir::FreeTypeVariableCollector collector{context};
-    std::visit(collector, fn_type);
+    auto free_type_variables = collect_free_variables(context, fn_type);
 
-    CHECK(collector.free_type_variables().size() == 1);
-    CHECK(collector.free_type_variables()[0].m_id == t1.m_id);
+    CHECK(free_type_variables.size() == 1);
+    CHECK(free_type_variables[0].m_id == t1.m_id);
   }
 }
 

--- a/type_checker_refactor.md
+++ b/type_checker_refactor.md
@@ -28,41 +28,49 @@ each layer. Worth a structured pass before more diverging constructs
 | `codegen/expression_generator.cpp:396-415` | `is_signed_type` lumps Never with non-numeric, throws |
 | `codegen/statement_generator.cpp:38-41,78-81` | Let/Assignment: skip alloca/store if RHS terminated |
 | `codegen/expression_generator.cpp:689-695,732-738` | Lambda body: skip implicit return if body terminated |
-| `hir/type_variable_substituter.hpp:80-82` | Pass-through |
-| `hir/type_variable_collapser.hpp:60-62` | Pass-through |
-| `hir/free_type_variable_collector.hpp:50` | Pass-through |
+| `hir/type_folder.hpp:50-51` | Generic `fold`: NeverType returns `m_never`; `walk` has no branch (no-op) |
 | `zir/context.hpp:62-63` | Pass-through HIR → ZIR |
 
 ## Approach
 
-A coherent Never story has three pieces:
+A coherent Never story has four pieces:
+
+**Semantics**: Never is the type an expression has when it produces no
+value for its immediate context. That's separate from whether the
+expression *transports* a value via control flow to a *carrier slot*
+elsewhere. `panic!()` is Never with no carrier. `return e` is Never; `e`
+flows to the function-return carrier. `break e` is Never; `e` flows to
+the enclosing-loop's result carrier. `loop {}` with no reachable break
+is Never. The carrier-slot framing is what lets return / break / panic /
+loop {} share one type-level story while differing only in what they
+ferry away.
 
 **Type-level**: Never is the bottom of a tiny subtype lattice. The
 operations the system uses are `unify` (HM equation-solving — Never as
 no-op is correct), `join` (least upper bound — needed for if/match/loop
 result types), and eventually `is_subtype` (Never coerces to anything).
+Carrier slots are themselves joined across all contributors (every
+`return e` in a function, every `break e` in a loop).
 
 **Inference boundary**: when inference finishes, residual unconstrained
 type variables that flowed from a Never expression default to Unit.
 Single rule, one place. Equivalent to Rust's never-type fallback.
 
-**Codegen**: a Never value is zero-sized and unreachable at runtime. The
-mangler gives it a canonical name; codegen treats it as
-no-op-on-store / unreachable-on-load.
+**Codegen**: a Never value is zero-sized and unreachable at runtime.
+Codegen treats it as no-op-on-store / unreachable-on-load. The mangler
+only needs a canonical name for Never if Never appears in a mangled
+signature — not necessary until `!` is user-facing as a return type.
 
 ## Tasks
 
 ### Tier 1 — small, immediate, high-leverage
 
-- [ ] Decide where unifier-substitution (collapse) is applied: either consolidate scattered per-binding `TypeVariableCollapser` calls into one explicit pre-mono pass, or fold `find()` into the monomorpher's walk. Either way, catch surviving tvars at one well-defined boundary
-- [ ] Convert "no TypeVariable" runtime errors in `mono/name_mangler.hpp` and `zir/context.hpp` to asserts once that boundary exists
+- [ ] Audit whether anything other than the let-binding generalizer (`hir/statement_checker.cpp:66`, where `collapse_types` runs to surface free tvars for the `TypeScheme`) can leak a `TypeVariable` past TypeChecker. If not, the existing `InternalCompilerError` throws in `mono/name_mangler.hpp` and `zir/context.hpp` document the invariant correctly and need no further work
 
 ### Tier 2 — medium, good payoff
 
-- [ ] Unify `TypeVariableSubstituter` / `TypeVariableCollapser` / `FreeTypeVariableCollector` under a single `TypeFolder<F>` abstraction
-- [ ] Generalize the never-type fallback. A local version landed in `hir/statement_checker.cpp:56-61` for let-bindings; promote to a single end-of-TypeChecker pass over residual tvars that flowed from Never
+- [ ] Generalize the never-type fallback. A local version landed in `hir/statement_checker.cpp:56-61` for let-bindings; promote to a single end-of-TypeChecker pass over residual tvars that flowed from Never. Build it on top of `walk`/`fold` in `hir/type_folder.hpp`
 - [ ] Move reachability into HIR as explicit field on `Block` (`is_divergent: bool`); codegen reads instead of recomputing via `current_block_terminated`. Would also let codegen drop the per-arm sanity-check asserts in `IfExpr`
-- [ ] Decide canonical mangle name for Never (`bot`); update mangler to accept it
 
 ### Tier 3 — larger, deferred
 


### PR DESCRIPTION
Some light refactoring to reduce duplicated code across similar folding/walking style functors dealing with the hir type system